### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - node_modules
 
 env:
+  - EMBER_TRY_SCENARIO=1.13
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,15 @@
 {
   "name": "ember-mobiledoc-editor",
   "dependencies": {
-    "ember": "1.13.7",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember": "~2.2.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.6",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
+    "ember-qunit": "^0.4.16",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
+    "jquery": "~2.1.1",
+    "loader.js": "ember-cli/loader.js#3.3.0",
+    "qunit": "~1.20.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,12 @@
 module.exports = {
   scenarios: [
     {
+      name: '1.13',
+      dependencies: {
+        'ember': '^1.13'
+      }
+    },
+    {
       name: 'default',
       dependencies: { }
     },

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
 /* jshint node: true */
 'use strict';
 var Funnel = require('broccoli-funnel');
-var resolve = require('resolve');
 var path = require('path');
 
 module.exports = {
   name: 'ember-mobiledoc-editor',
+
   treeForVendor: function() {
-    var mainPath = resolve.sync('mobiledoc-kit');
-    var mainDir = path.dirname(mainPath);
-    var files = new Funnel(mainDir + '/../../', {
+    var distDir = path.join(
+      path.dirname(require.resolve('mobiledoc-kit/package.json')),
+      'dist'
+    );
+
+    var files = new Funnel(distDir, {
       files: [
         'css/mobiledoc-kit.css',
         'global/mobiledoc-kit.js',
@@ -19,9 +22,9 @@ module.exports = {
     });
     return files;
   },
+
   included: function(app) {
     app.import('vendor/mobiledoc-kit/css/mobiledoc-kit.css');
     app.import('vendor/mobiledoc-kit/global/mobiledoc-kit.js');
   }
-
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
@@ -44,8 +43,7 @@
     "mobiledoc-kit": "^0.6.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
-    "ember-wormhole": "^0.3.4",
-    "resolve": "^1.1.6"
+    "ember-wormhole": "^0.3.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This fixes test failures in ember-beta, updates a few dependencies, and
simplifies the addon `treeForVendor` code

  * drop `ember-cli-htmlbars` devDep
  * drop `resolve` dep in favor of built-in require.resolve
  * update bower deps to use ember stable (2.2.0) by default
  * add ember-1.13 ember-try scenario
  * update other bower deps, including ember-qunit (version 0.4.9 was causing test failures in ember-beta and -canary)