### PR TITLE
Test that `postModel` is exposed to component cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The component will be provided with the following `attrs`:
   * `cancelCard`, an action toggling this card to display mode without saving (this action is a no-op if the card is already in display mode) (see the ["cancel Mobiledoc card action](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md#available-hooks))
   * `cardName` the name of this card
   * `editor` A reference to the [mobiledoc-kit](https://github.com/bustlelabs/mobiledoc-kit)
-  * `cardSection` A reference to this card's `cardSection` model in the editor's abstract tree. This may be necessary to do programmatic editing (such as moving the card via the `postEditor#moveSection` API that Mobiledoc editor provides)
+  * `postModel` A reference to this card's model in the editor's abstract tree. This may be necessary to do programmatic editing (such as moving the card via the `postEditor#moveSection` API that Mobiledoc editor provides)
 
 ### Developing ember-mobiledoc-editor
 

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -181,7 +181,7 @@ export default Component.extend({
           data: payload,
           callbacks: env,
           editor,
-          section: env.section
+          postModel: env.postModel
         });
         Ember.run.schedule('afterRender', () => {
           this.get('componentCards').pushObject(card);

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -26,7 +26,7 @@
   {{#ember-wormhole to=card.destinationElementId}}
     {{component card.cardName
         editor=editor
-        cardSection=card.section
+        postModel=card.postModel
         cardName=card.cardName
         data=card.data
         editCard=(action card.callbacks.edit)

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -266,6 +266,27 @@ test('it adds a component in display mode to the mobiledoc editor', function(ass
   assert.ok(this.$(`#demo-card-editor`).length, 'Card changed to edit mode');
 });
 
+test('exposes the `postModel` on the card component', function(assert) {
+  assert.expect(2);
+  this.registry.register('component:demo-card', Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.ok(!!this.get('postModel'), 'card is passed postModel');
+    }
+  }));
+  this.registry.register('template:components/demo-card',
+                         hbs`<div id="demo-card"></div>`);
+  this.set('cards', [createComponentCard('demo-card')]);
+  this.render(hbs`
+    {{#mobiledoc-editor cards=cards as |editor|}}
+      <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
+    {{/mobiledoc-editor}}
+  `);
+
+  this.$('button#add-card').click();
+  assert.ok(this.$(`#demo-card`).length, 'Card added in display mode');
+});
+
 test('it adds a card and removes an active blank section', function(assert) {
   assert.expect(4);
   this.registry.register('template:components/demo-card', hbs`


### PR DESCRIPTION
The signature for rendering a card [has changed](https://github.com/bustlelabs/mobiledoc-kit/issues/235) and now exposes `env.postModel` instead of `env.section`. This adds tests to ensure that this property is exposed via to cards that are rendered as ember components.