### PR TITLE
Expose `toggleSection` action, deprecate `toggleSectionTagName`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  # See https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to
+  # modified to not use sudo (just puts $PWD on the path so that $PWD/phantomjs is the phantom used
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - export PATH=$PWD:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ state of the editor:
 Additionally `editor` provides the following actions:
 
 * `toggleMarkup`, toggling the passed markup tag name in the current selection.
-* `toggleSectionTagName`, toggling the passed section tag name in the current
+* `toggleSection`, toggling the passed section tag name in the current
   selection.
 * `toggleLink`, toggling the linking of a selection. The user will be prompted
    for a URL if required.

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -7,6 +7,10 @@ let { capitalize, camelize } = Ember.String;
 export const ADD_HOOK = 'addComponent';
 export const REMOVE_HOOK = 'removeComponent';
 const EDITOR_CARD_SUFFIX = '-editor';
+const EMPTY_MOBILEDOC = {
+  version: '0.2.0',
+  sections: [[], []]
+};
 
 function arrayToMap(array, propertyName) {
   let map = Object.create(null);
@@ -47,10 +51,7 @@ export default Component.extend({
     this._super(...arguments);
     let mobiledoc = this.get('mobiledoc');
     if (!mobiledoc) {
-      mobiledoc = {
-        version: '0.2.0',
-        sections: [[], []]
-      };
+      mobiledoc = EMPTY_MOBILEDOC;
       this.set('mobiledoc', mobiledoc);
     }
     this.set('componentCards', Ember.A([]));
@@ -66,24 +67,17 @@ export default Component.extend({
       editor.run(postEditor => postEditor.toggleMarkup(markupTagName));
     },
 
+    toggleSection(newTagName) {
+      let editor = this.get('editor');
+      editor.run(postEditor => postEditor.toggleSection(newTagName));
+    },
+
+    // Deprecated
     toggleSectionTagName(newTagName) {
-      const editor = this.get('editor');
-      const sections = editor.activeSections;
-      let hasSectionsOfTagName = false;
-
-      editor.run(postEditor => {
-        hasSectionsOfTagName = Ember.A(sections).any(
-          s => s.tagName === newTagName);
-
-        if (hasSectionsOfTagName) {
-          sections.forEach(s => postEditor.resetSectionTagName(s));
-        } else {
-          sections.forEach(s => postEditor.changeSectionTagName(s, newTagName));
-        }
-        postEditor.scheduleAfterRender(() => {
-          editor.selectSections(sections);
-        });
-      });
+      Ember.warn('toggleSectionTagName is deprecated. Use toggleSection instead',
+                 false,
+                 {id: 'mobiledoc-editor-toggleSectionTagName'});
+      this.send('toggleSection', newTagName);
     },
 
     createListSection(tagName) {

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -6,6 +6,7 @@
   toggleLink=(action 'toggleLink')
   addCard=(action 'addCard')
   addCardInEditMode=(action 'addCardInEditMode')
+  toggleSection=(action 'toggleSection')
   toggleSectionTagName=(action 'toggleSectionTagName')
   createListSection=(action 'createListSection')
 )}}

--- a/addon/components/mobiledoc-section-button/component.js
+++ b/addon/components/mobiledoc-section-button/component.js
@@ -26,6 +26,6 @@ export default Component.extend({
   click() {
     let editor = this.get('editor');
     let forProperty = this.get('for');
-    editor.toggleSectionTagName(forProperty);
+    editor.toggleSection(forProperty);
   }
 });

--- a/addon/components/mobiledoc-toolbar/template.hbs
+++ b/addon/components/mobiledoc-toolbar/template.hbs
@@ -25,7 +25,7 @@
   <button
     title="Heading"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isH1 'active'}}"
-    {{action editor.toggleSectionTagName 'h1'}}>
+    {{action editor.toggleSection 'h1'}}>
     Headline
   </button>
 </li>
@@ -33,7 +33,7 @@
   <button
     title="Subheading"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isH2 'active'}}"
-    {{action editor.toggleSectionTagName 'h2'}}>
+    {{action editor.toggleSection 'h2'}}>
     Subheadline
   </button>
 </li>
@@ -41,7 +41,7 @@
   <button
     title="Block Quote"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isBlockquote 'active'}}"
-    {{action editor.toggleSectionTagName 'blockquote'}}>
+    {{action editor.toggleSection 'blockquote'}}>
     <i class="icon-quote-block"></i>
     Blockquote
   </button>
@@ -50,7 +50,7 @@
   <button
     title="Pull Quote"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isPullQuote 'active'}}"
-    {{action editor.toggleSectionTagName 'pull-quote'}}>
+    {{action editor.toggleSection 'pull-quote'}}>
     Pull-quote
   </button>
 </li>
@@ -58,7 +58,7 @@
   <button
     title="List"
     class="mobiledoc-toolbar__button"
-    {{action editor.createListSection 'ul'}}>
+    {{action editor.toggleSection 'ul'}}>
     Unordered List
   </button>
 </li>
@@ -66,7 +66,7 @@
   <button
     title="Numbered List"
     class="mobiledoc-toolbar__button"
-    {{action editor.createListSection 'ol'}}>
+    {{action editor.toggleSection 'ol'}}>
     Ordered List
   </button>
 </li>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "broccoli-funnel": "^0.2.8",
-    "mobiledoc-kit": "^0.7.0",
+    "mobiledoc-kit": "^0.7.2",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4"

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -50,6 +50,7 @@ test('it boots the mobiledoc editor', function(assert) {
     'Mobiledoc editor is booted'
   );
 });
+
 test('it boots mobiledoc editor with mobiledoc', function(assert) {
   assert.expect(2);
   let mobiledoc = simpleMobileDoc('Howdy');
@@ -121,7 +122,37 @@ test('it bolds the text and fires `on-change`', function(assert) {
   );
 });
 
-test('it toggles the section type and fires `on-change`', function(assert) {
+test('it exposes "toggleSection" which toggles the section type and fires `on-change`', function(assert) {
+  assert.expect(6);
+
+  let onChangeCount = 0;
+
+  let text = 'Howdy';
+  this.set('mobiledoc', simpleMobileDoc(text));
+  this.on('on-change', () => onChangeCount++);
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=mobiledoc on-change=(action 'on-change') as |editor|}}
+      <button {{action editor.toggleSection 'h2'}}>H2</button>
+    {{/mobiledoc-editor}}
+  `);
+  const textNode = this.$(`p:contains(${text})`)[0].firstChild;
+  selectRange(textNode, 0, textNode, text.length);
+
+  assert.ok(!this.$('h2').length, 'precond - no h2');
+  assert.equal(onChangeCount, 0, 'precond - no on-change');
+
+  this.$('button').click();
+
+  assert.equal(onChangeCount, 1, 'fires on-change');
+  assert.ok(!!this.$('h2:contains(Howdy)').length, 'Changes to h2 tag');
+
+  onChangeCount = 0;
+  this.$('button').click();
+  assert.equal(onChangeCount, 1, 'fires on-change again');
+  assert.ok(!this.$('h2').length, 'toggles h2 tag off again');
+});
+
+test('it exposes "toggleSectionTagName" (deprecated) which toggles the section type and fires `on-change`', function(assert) {
   assert.expect(6);
 
   let onChangeCount = 0;

--- a/tests/integration/components/mobiledoc-section-button/component-test.js
+++ b/tests/integration/components/mobiledoc-section-button/component-test.js
@@ -10,7 +10,7 @@ moduleForComponent('mobiledoc-section-button', 'Integration | Component | mobile
 
 test('it displays button', function(assert) {
   let editor = EObject.create({
-    toggleSectionTagName() {},
+    toggleSection() {},
     activeSectionTagNames: {}
   });
   this.set('editor', editor);
@@ -35,7 +35,7 @@ test('it displays button', function(assert) {
 
 test('it yields for html', function(assert) {
   this.set('editor', {
-    toggleSectionTagName() {},
+    toggleSection() {},
     activeSectionTagNames: {}
   });
   this.render(hbs`
@@ -50,12 +50,12 @@ test('it yields for html', function(assert) {
     'text is yielded');
 });
 
-test('it calls toggleSectionTagName on click', function(assert) {
+test('it calls toggleSection on click', function(assert) {
   assert.expect(2);
   this.set('editor', {
-    toggleSectionTagName(tag) {
-      assert.ok(true, 'toggleSectionTagName called');
-      assert.equal(tag, 'h1', 'toggleSectionTagName called with "for" value');
+    toggleSection(tag) {
+      assert.ok(true, 'toggleSection called');
+      assert.equal(tag, 'h1', 'toggleSection called with "for" value');
     },
     activeSectionTagNames: {}
   });

--- a/tests/integration/components/mobiledoc-toolbar/component-test.js
+++ b/tests/integration/components/mobiledoc-toolbar/component-test.js
@@ -13,7 +13,7 @@ test('it displays buttons', function(assert) {
 
   this.set('editor', {
     toggleMarkup() {},
-    toggleSectionTagName() {},
+    toggleSection() {},
     createListSection() {},
     toggleLink() {}
   });


### PR DESCRIPTION
This PR to mobiledoc-kit added `postEditor#toggleSection`: https://github.com/bustlelabs/mobiledoc-kit/pull/248.

This updates ember-mobiledoc-editor to use `toggleSection` instead of the more ad-hoc way it was using of changing section types.