### PR TITLE
Minimize rerender from new Mobiledoc

### DIFF
--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -66,6 +66,35 @@ test('it boots mobiledoc editor with mobiledoc', function(assert) {
   );
 });
 
+test('it does not update the editor when the same mobiledoc is set', function(assert) {
+  assert.expect(2);
+  let mobiledoc = simpleMobileDoc('Howdy');
+  let editor;
+  let createdEditors = 0;
+
+  this.set('mobiledoc', mobiledoc);
+  this.register('component:gather-editor', Ember.Component.extend({
+    didRender() {
+      createdEditors++;
+      editor = this.get('editor');
+    }
+  }));
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=(readonly mobiledoc)
+                        on-change=(action (mut mobiledoc)) as |editor|}}
+      {{gather-editor editor=editor.editor}}
+    {{/mobiledoc-editor}}
+  `);
+
+  assert.equal(createdEditors, 1, 'initial editor created');
+
+  editor.run((postEditor) => {
+    postEditor.insertText(editor.range.tail, 'Friend');
+  });
+
+  assert.equal(createdEditors, 1, 'editor maintained');
+});
+
 test('it updates the editor when the mobiledoc changes', function(assert) {
   assert.expect(2);
   let mobiledoc1 = simpleMobileDoc('Howdy');


### PR DESCRIPTION
Move the editor destroy/setup flow into willRender and didRender. Compare a new mobiledoc to the local mobiledoc and the upstream one before destroying and recreating the editor.

Refs #42