### PR TITLE
ensure addCard action sets range

### DIFF
--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -260,7 +260,6 @@ test('toolbar buttons can be active', function(assert) {
   assert.ok(!button.hasClass('active'), 'heading button is no longer active');
 });
 
-
 test('toolbar has list insertion button', function(assert) {
   let text = 'abc';
   this.set('mobiledoc', simpleMobileDoc(text));
@@ -392,6 +391,42 @@ test('it adds a card and removes an active blank section', function(assert) {
   this.$('button#add-card').click();
   assert.equal(this.$('.mobiledoc-editor p').length, 0, 'no blank section');
   assert.equal(this.$('#demo-card').length, 1, 'card section exists');
+});
+
+test('it adds a card and focuses the cursor at the end of the card', function(assert) {
+  assert.expect(6);
+  this.registry.register('template:components/demo-card', hbs`
+    <div id="demo-card"><button id='edit-card' {{action editCard}}></button></div>
+   `);
+  this.set('cards', [
+    createComponentCard('demo-card')
+  ]);
+  let editor;
+  this.on('expose-editor', (hash) => {
+    editor = hash.editor;
+  });
+  this.set('mobiledoc', simpleMobileDoc(''));
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=mobiledoc cards=cards as |editor|}}
+      <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
+      <button id='get-editor' {{action 'expose-editor' editor}}></button>
+    {{/mobiledoc-editor}}
+  `);
+
+  moveCursorTo(this, '.mobiledoc-editor p');
+  this.$('button#get-editor').click();
+  this.$('button#add-card').click();
+  assert.equal(this.$('#demo-card').length, 1, 'card section exists');
+
+  let cardWrapper = this.$('#demo-card').parents('.__mobiledoc-card');
+  assert.ok(!!cardWrapper.length, 'precond - card wrapper is found');
+  let cursorElement = cardWrapper[0].nextSibling;
+  assert.ok(!!cursorElement, 'precond - cursor element is found');
+
+  assert.ok(window.getSelection().focusNode === cursorElement, 'selection focus is on cursor element');
+  assert.ok(window.getSelection().anchorNode === cursorElement, 'selection anchor is on cursor element');
+  assert.ok(document.activeElement === $('.__mobiledoc-editor')[0],
+               'document.activeElement is correct');
 });
 
 test('it has `addCardInEditMode` action to add card in edit mode', function(assert) {


### PR DESCRIPTION
Fixes https://github.com/bustlelabs/mobiledoc-kit/issues/286
If the range is not set explicitly, the browser page can end up in a
state where:
  * the document.activeElement is outside the editor element
    (it's the button that the user clicked on to add the card)
  * the window.getSelection() is still inside the editor element
  * on the next keystroke, the browser will insert text into the
    contenteditable editor element at the selection, but only the
    mutation observer listeners will fire. This can result in an
    un-mapped text node being added to the mobiledoc editor, which
    causes errors to be thrown

cc @mixonic Any idea for how to write a better test for this? The test currently finds the zero-width non-joiner element around the card and ensures that is what is selected.