### PR TITLE
Use mobiledoc-kit's AMD build

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -1,7 +1,7 @@
-/* global Mobiledoc */
 import Ember from 'ember';
 import layout from './template';
-
+import Editor from 'mobiledoc-kit/editor/editor';
+import Range from 'mobiledoc-kit/utils/cursor/range';
 let { computed, Component } = Ember;
 let { capitalize, camelize } = Ember.String;
 
@@ -12,9 +12,6 @@ const EMPTY_MOBILEDOC = {
   version: '0.2.0',
   sections: [[], []]
 };
-
-const MobiledocEditor = Mobiledoc.Editor;
-const MobiledocRange  = Mobiledoc.Range;
 
 function arrayToMap(array, propertyName) {
   let map = Object.create(null);
@@ -212,7 +209,7 @@ export default Component.extend({
         this.get('componentCards').removeObject(card);
       }
     };
-    editor = new MobiledocEditor(editorOptions);
+    editor = new Editor(editorOptions);
     editor.willRender(() => {
       // The editor's render/rerender will happen after this `editor.willRender`,
       // so we explicitly start a runloop here if there is none, so that the
@@ -295,7 +292,7 @@ export default Component.extend({
       // This prevents problems with the editor element being out-of-focus
       // but the window's selection still in the editor element.
       // See https://github.com/bustlelabs/mobiledoc-kit/issues/286
-      let range = new MobiledocRange(card.tailPosition());
+      let range = new Range(card.tailPosition());
       postEditor.setRange(range);
     });
   }

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = {
     files.push(new Funnel(distDirFor('mobiledoc-kit'), {
       files: [
         'css/mobiledoc-kit.css',
-        'global/mobiledoc-kit.js',
-        'global/mobiledoc-kit.map'
+        'amd/mobiledoc-kit.js',
+        'amd/mobiledoc-kit.map'
       ],
       destDir: 'mobiledoc-kit'
     }));
@@ -32,7 +32,7 @@ module.exports = {
     if (rendererDir) {
       files.push(new Funnel(rendererDir, {
         files: [
-          'global/mobiledoc-dom-renderer.js'
+          'amd/mobiledoc-dom-renderer.js'
         ],
         destDir: 'mobiledoc-dom-renderer'
       }));
@@ -43,10 +43,10 @@ module.exports = {
 
   included: function(app) {
     app.import('vendor/mobiledoc-kit/css/mobiledoc-kit.css');
-    app.import('vendor/mobiledoc-kit/global/mobiledoc-kit.js');
+    app.import('vendor/mobiledoc-kit/amd/mobiledoc-kit.js');
     var rendererDir = distDirFor('mobiledoc-dom-renderer');
     if (rendererDir) {
-      app.import('vendor/mobiledoc-dom-renderer/global/mobiledoc-dom-renderer.js');
+      app.import('vendor/mobiledoc-dom-renderer/amd/mobiledoc-dom-renderer.js');
     }
   }
 };

--- a/tests/unit/utils/create-component-card-test.js
+++ b/tests/unit/utils/create-component-card-test.js
@@ -1,6 +1,6 @@
-/* global MobiledocDOMRenderer */
 import createComponentCard from 'ember-mobiledoc-editor/utils/create-component-card';
 import { module, test } from 'qunit';
+import MobiledocDOMRenderer from 'mobiledoc-dom-renderer';
 
 module('Unit | Utility | create component card');
 


### PR DESCRIPTION
This is a first step toward fastboot-compatibility, since it eliminates eval-time use of `document`.

Plus I think named modules are preferable to globals whenever possible.