### PR TITLE
Exposes `serializeVersion` property on `{{mobiledoc-editor}}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The components accepts these arguments:
 * `autofocus` boolean
 * `placeholder` string -- the placeholder text to display when the mobiledoc is blank
 * `options` hash -- any properties in the `options` hash will be passed to the ContentKitEditor constructor
+* `serializeVersion` string -- The mobiledoc version to serialize to when firing the on-change action. Default: 0.3.0
 
 
 Of course often you want to provide a user interface to bold text, create

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from './template';
 import Editor from 'mobiledoc-kit/editor/editor';
 import Range from 'mobiledoc-kit/utils/cursor/range';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 let { computed, Component } = Ember;
 let { capitalize, camelize } = Ember.String;
 
@@ -9,8 +10,11 @@ export const ADD_HOOK = 'addComponent';
 export const REMOVE_HOOK = 'removeComponent';
 const EDITOR_CARD_SUFFIX = '-editor';
 const EMPTY_MOBILEDOC = {
-  version: '0.2.0',
-  sections: [[], []]
+  version: MOBILEDOC_VERSION,
+  markups: [],
+  atoms: [],
+  cards: [],
+  sections: []
 };
 
 function arrayToMap(array, propertyName) {
@@ -32,6 +36,7 @@ export default Component.extend({
   placeholder: 'Write here...',
   spellcheck: true,
   autofocus: true,
+  serializeVersion: MOBILEDOC_VERSION,
 
   options: {},
 
@@ -232,7 +237,8 @@ export default Component.extend({
     });
     editor.on('update', () => {
       Ember.run.join(() => {
-        let updatedMobileDoc = editor.serialize();
+        let serializeVersion = this.get('serializeVersion');
+        let updatedMobileDoc = editor.serialize(serializeVersion);
         this._localMobiledoc = updatedMobileDoc;
         this.sendAction('on-change', updatedMobileDoc);
       });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4",
-    "mobiledoc-kit": "^0.8.0"
+    "mobiledoc-kit": "^0.8.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Also updates mobiledoc-kit to latest (^0.8.2) and updates tests to use
mobiledoc version 0.3.0