### PR TITLE
Pass `payload` to card components, replaces `data`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ will be used:
 
 The component will be provided with the following `attrs`:
 
-  * `data`, the data payload for this card. *Note* the data is disconnected from the card's payload in the serialized mobiledoc. To update the mobiledoc payload, use the `saveCard` or `mutData` actions.
+  * `payload`, the payload for this card. *Note* the payload object is disconnected from the card's payload in the serialized mobiledoc. To update the mobiledoc payload, use the `saveCard` action.
   * `editCard`, an action for toggling this card into edit mode (this action is a no-op if the card is already in edit mode)
   * `removeCard`, an action for removing this card (see the ["remove" Mobiledoc card action](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md#available-hooks))
-  * `saveCard`, an action accepting new data for the card payload, then saving
-    that data and toggling this card into display mode can optionally be passed an extra `false` argument to avoid toggling to display mode (see the ["save Mobiledoc card action](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md#available-hooks))
+  * `saveCard`, an action accepting new payload for the card, then saving
+    that payload and toggling this card into display mode can optionally be passed an extra `false` argument to avoid toggling to display mode (see the ["save Mobiledoc card action](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md#available-hooks))
   * `cancelCard`, an action toggling this card to display mode without saving (this action is a no-op if the card is already in display mode) (see the ["cancel Mobiledoc card action](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md#available-hooks))
   * `cardName` the name of this card
   * `editor` A reference to the [mobiledoc-kit](https://github.com/bustlelabs/mobiledoc-kit)

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -40,7 +40,7 @@ export default Component.extend({
 
   options: {},
 
-  // merge in named options with the `options` property data bag
+  // merge in named options with the `options` property data-bag
   editorOptions: computed(function() {
     let options = this.get('options');
 
@@ -108,13 +108,13 @@ export default Component.extend({
       editor.selectSections([listItem]);
     },
 
-    addCard(cardName, data={}) {
-      this._addCard(cardName, data);
+    addCard(cardName, payload={}) {
+      this._addCard(cardName, payload);
     },
 
-    addCardInEditMode(cardName, data={}) {
+    addCardInEditMode(cardName, payload={}) {
       let editMode = true;
-      this._addCard(cardName, data, editMode);
+      this._addCard(cardName, payload, editMode);
     },
 
     toggleLink() {
@@ -200,7 +200,7 @@ export default Component.extend({
         let card = Ember.Object.create({
           destinationElementId,
           cardName,
-          data: payload,
+          payload,
           callbacks: env,
           editor,
           postModel: env.postModel
@@ -280,11 +280,11 @@ export default Component.extend({
     editor.destroy();
   },
 
-  _addCard(cardName, data, editMode=false) {
+  _addCard(cardName, payload, editMode=false) {
     let editor = this.get('editor');
     let section = editor.activeSection;
     editor.run(postEditor => {
-      let card = editor.builder.createCardSection(cardName, data);
+      let card = editor.builder.createCardSection(cardName, payload);
       if (editMode) {
         editor.editCard(card);
       }

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -25,11 +25,14 @@
 
 {{#each componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
+    {{! LEGACY: Payload is passed as the legacy "data" attr below. This
+        should be removed before 1.0 }}
     {{component card.cardName
         editor=editor
         postModel=card.postModel
         cardName=card.cardName
-        data=card.data
+        payload=card.payload
+        data=card.payload
         editCard=(action card.callbacks.edit)
         saveCard=(action card.callbacks.save)
         cancelCard=(action card.callbacks.cancel)


### PR DESCRIPTION
Per https://github.com/bustlelabs/ember-mobiledoc-dom-renderer/pull/11 we have inconsistent card component APIs across the editor and renderer codebase. This adds `payload` as an attr for card components. `data` should be removed before 1.0.