### PR TITLE
Adds createComponentAtom util to use Ember.Component as atoms

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -6,8 +6,11 @@ import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 let { computed, Component } = Ember;
 let { capitalize, camelize } = Ember.String;
 
-export const ADD_HOOK = 'addComponent';
-export const REMOVE_HOOK = 'removeComponent';
+export const ADD_CARD_HOOK = 'addComponent';
+export const REMOVE_CARD_HOOK = 'removeComponent';
+export const ADD_ATOM_HOOK = 'addAtomComponent';
+export const REMOVE_ATOM_HOOK = 'removeAtomComponent';
+
 const EDITOR_CARD_SUFFIX = '-editor';
 const EMPTY_MOBILEDOC = {
   version: MOBILEDOC_VERSION,
@@ -61,6 +64,7 @@ export default Component.extend({
       this.set('mobiledoc', mobiledoc);
     }
     this.set('componentCards', Ember.A([]));
+    this.set('componentAtoms', Ember.A([]));
     this.set('linkOffsets', null);
     this.set('activeMarkupTagNames', {});
     this.set('activeSectionTagNames', {});
@@ -184,7 +188,7 @@ export default Component.extend({
     let editorOptions = this.get('editorOptions');
     editorOptions.mobiledoc = mobiledoc;
     editorOptions.cardOptions = {
-      [ADD_HOOK]: ({env, options, payload}, isEditing=false) => {
+      [ADD_CARD_HOOK]: ({env, options, payload}, isEditing=false) => {
         let cardId = Ember.uuid();
         let cardName = env.name;
         if (isEditing) {
@@ -210,8 +214,35 @@ export default Component.extend({
         });
         return { card, element };
       },
-      [REMOVE_HOOK]: (card) => {
+      [ADD_ATOM_HOOK]: ({env, options, payload, value}) => {
+        let atomId = Ember.uuid();
+        let atomName = env.name;
+        let destinationElementId = `mobiledoc-editor-atom-${atomId}`;
+        let element = document.createElement('span');
+        element.id = destinationElementId;
+
+        // The data must be copied to avoid sharing the reference
+        payload = Ember.copy(payload, true);
+
+        let atom = Ember.Object.create({
+          destinationElementId,
+          atomName,
+          payload,
+          value,
+          callbacks: env,
+          editor,
+          postModel: env.postModel
+        });
+        Ember.run.schedule('afterRender', () => {
+          this.get('componentAtoms').pushObject(atom);
+        });
+        return { atom, element };
+      },
+      [REMOVE_CARD_HOOK]: (card) => {
         this.get('componentCards').removeObject(card);
+      },
+      [REMOVE_ATOM_HOOK]: (atom) => {
+        this.get('componentAtoms').removeObject(atom);
       }
     };
     editor = new Editor(editorOptions);
@@ -277,7 +308,9 @@ export default Component.extend({
 
   willDestroyElement() {
     let editor = this.get('editor');
-    editor.destroy();
+    try {
+      editor.destroy();
+    } catch(e) {}
   },
 
   _addCard(cardName, payload, editMode=false) {

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -39,3 +39,14 @@
         removeCard=(action card.callbacks.remove)}}
   {{/ember-wormhole}}
 {{/each}}
+
+{{#each componentAtoms as |atom|}}
+  {{#ember-wormhole to=atom.destinationElementId}}
+    {{component atom.atomName
+        editor=editor
+        postModel=atom.postModel
+        atomName=atom.atomName
+        payload=atom.payload
+        value=atom.value}}
+  {{/ember-wormhole}}
+{{/each}}

--- a/addon/utils/create-component-atom.js
+++ b/addon/utils/create-component-atom.js
@@ -1,0 +1,31 @@
+const RENDER_TYPE = 'dom';
+
+import { ADD_ATOM_HOOK, REMOVE_ATOM_HOOK } from '../components/mobiledoc-editor/component';
+
+function renderFallback() {
+  let element = document.createElement('span');
+  element.innerHTML = '[placeholder for Ember atom]';
+  return element;
+}
+
+export default function createComponentAtom(name) {
+
+  return {
+    name,
+    type: RENDER_TYPE,
+    render(atomArg) {
+      let {env, options} = atomArg;
+      if (!options[ADD_ATOM_HOOK]) {
+        return renderFallback();
+      }
+
+      let { atom, element } = options[ADD_ATOM_HOOK](atomArg);
+      let { onTeardown } = env;
+
+      onTeardown(() => options[REMOVE_ATOM_HOOK](atom));
+
+      return element;
+    }
+  };
+
+}

--- a/addon/utils/create-component-card.js
+++ b/addon/utils/create-component-card.js
@@ -1,6 +1,6 @@
 const RENDER_TYPE = 'dom';
 
-import { ADD_HOOK, REMOVE_HOOK } from '../components/mobiledoc-editor/component';
+import { ADD_CARD_HOOK, REMOVE_CARD_HOOK } from '../components/mobiledoc-editor/component';
 
 function renderFallback() {
   let element = document.createElement('div');
@@ -15,28 +15,28 @@ export default function createComponentCard(name) {
     type: RENDER_TYPE,
     render(cardArg) {
       let {env, options} = cardArg;
-      if (!options[ADD_HOOK]) {
+      if (!options[ADD_CARD_HOOK]) {
         return renderFallback();
       }
 
-      let { card, element } = options[ADD_HOOK](cardArg);
+      let { card, element } = options[ADD_CARD_HOOK](cardArg);
       let { onTeardown } = env;
 
-      onTeardown(() => options[REMOVE_HOOK](card));
+      onTeardown(() => options[REMOVE_CARD_HOOK](card));
 
       return element;
     },
     edit(cardArg) {
       let {env, options} = cardArg;
-      if (!options[ADD_HOOK]) {
+      if (!options[ADD_CARD_HOOK]) {
         return renderFallback();
       }
 
       let isEditing = true;
-      let { card, element } = options[ADD_HOOK](cardArg, isEditing);
+      let { card, element } = options[ADD_CARD_HOOK](cardArg, isEditing);
       let { onTeardown } = env;
 
-      onTeardown(() => options[REMOVE_HOOK](card));
+      onTeardown(() => options[REMOVE_CARD_HOOK](card));
 
       return element;
     }

--- a/tests/unit/utils/create-component-atom-test.js
+++ b/tests/unit/utils/create-component-atom-test.js
@@ -1,0 +1,33 @@
+import createComponentAtom from 'ember-mobiledoc-editor/utils/create-component-atom';
+import { module, test } from 'qunit';
+import MobiledocDOMRenderer from 'mobiledoc-dom-renderer';
+
+module('Unit | Utility | create component atom');
+
+test('it creates an atom', function(assert) {
+  var result = createComponentAtom('foo-atom');
+  assert.ok(result.name === 'foo-atom' &&
+            result.type === 'dom' &&
+            typeof result.render === 'function',
+    'created a named atom'
+  );
+});
+
+test('it creates a renderable atom', function(assert) {
+  var atom = createComponentAtom('foo-atom');
+  let renderer = new MobiledocDOMRenderer({atoms: [atom]});
+
+  let {result} = renderer.render({
+    version: '0.3.0',
+    atoms: [
+      ['foo-atom', '', {}]
+    ],
+    sections: [
+      [1, 'P', [
+        [1, [], 0, 0]]
+      ]
+    ]
+  });
+
+  assert.ok(result, 'atom rendered');
+});


### PR DESCRIPTION
Renames `{ADD,REMOVE}_HOOK` hooks to `{ADD,REMOVE}_CARD_HOOK`, are these public?

I haven't added an `addAtom` action yet as it seems like that might be down to implementors to implement. 

My personal use-case will display a pop-over to choose something to insert etc… so much like the link tool would need to stash the cursor position & use that to insert the atom. However, a basic `addAtom` action which just inserts at the current cursor position could be useful for others, open to suggestions there.