### PR TITLE
Fix README syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ export default Ember.Component.extend({
     return [
       createComponentCard('demo-card')
     ];
-  });
+  })
 });
 ```
 


### PR DESCRIPTION
The `;`-character in the card-example yields a syntax error. Removed it in this commit.