### PR TITLE
upgrade mobiledoc-kit to 0.9.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4",
-    "mobiledoc-kit": "^0.8.5"
+    "mobiledoc-kit": "^0.9.0-beta.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Upgrades to mobiledoc-kit 0.9.0-beta.1