### PR TITLE
Expose card env to ember component cards

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -205,7 +205,7 @@ export default Component.extend({
           destinationElementId,
           cardName,
           payload,
-          callbacks: env,
+          env,
           editor,
           postModel: env.postModel
         });

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -33,9 +33,10 @@
         cardName=card.cardName
         payload=card.payload
         data=card.payload
-        editCard=(action card.callbacks.edit)
-        saveCard=(action card.callbacks.save)
-        cancelCard=(action card.callbacks.cancel)
-        removeCard=(action card.callbacks.remove)}}
+        env=card.env
+        editCard=(action card.env.edit)
+        saveCard=(action card.env.save)
+        cancelCard=(action card.env.cancel)
+        removeCard=(action card.env.remove)}}
   {{/ember-wormhole}}
 {{/each}}


### PR DESCRIPTION
My understanding of mobiledoc-kit's Card API is that `env` is part of the public API that a card receives from mobiledoc. If so, then it should be accessible to ember component cards.

An example of a property accessible to cards that wasn't accessible to ember component cards is `env.isInEditor`.