### PR TITLE
[CLEANUP] Remove deprecated `toggleSectionTagName`

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -81,14 +81,6 @@ export default Component.extend({
       editor.run(postEditor => postEditor.toggleSection(newTagName));
     },
 
-    // Deprecated
-    toggleSectionTagName(newTagName) {
-      Ember.warn('toggleSectionTagName is deprecated. Use toggleSection instead',
-                 false,
-                 {id: 'mobiledoc-editor-toggleSectionTagName'});
-      this.send('toggleSection', newTagName);
-    },
-
     createListSection(tagName) {
       const editor = this.get('editor');
       const section = editor.activeSections[0];

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -7,7 +7,6 @@
   addCard=(action 'addCard')
   addCardInEditMode=(action 'addCardInEditMode')
   toggleSection=(action 'toggleSection')
-  toggleSectionTagName=(action 'toggleSectionTagName')
   createListSection=(action 'createListSection')
 )}}
 

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -318,36 +318,6 @@ test('it exposes "toggleSection" which toggles the section type and fires `on-ch
   assert.ok(!this.$('h2').length, 'toggles h2 tag off again');
 });
 
-test('it exposes "toggleSectionTagName" (deprecated) which toggles the section type and fires `on-change`', function(assert) {
-  assert.expect(6);
-
-  let onChangeCount = 0;
-
-  let text = 'Howdy';
-  this.set('mobiledoc', simpleMobileDoc(text));
-  this.on('on-change', () => onChangeCount++);
-  this.render(hbs`
-    {{#mobiledoc-editor mobiledoc=mobiledoc on-change=(action 'on-change') as |editor|}}
-      <button {{action editor.toggleSectionTagName 'h2'}}>H2</button>
-    {{/mobiledoc-editor}}
-  `);
-  const textNode = this.$(`p:contains(${text})`)[0].firstChild;
-  selectRange(textNode, 0, textNode, text.length);
-
-  assert.ok(!this.$('h2').length, 'precond - no h2');
-  assert.equal(onChangeCount, 0, 'precond - no on-change');
-
-  this.$('button').click();
-
-  assert.equal(onChangeCount, 1, 'fires on-change');
-  assert.ok(!!this.$('h2:contains(Howdy)').length, 'Changes to h2 tag');
-
-  onChangeCount = 0;
-  this.$('button').click();
-  assert.equal(onChangeCount, 1, 'fires on-change again');
-  assert.ok(!this.$('h2').length, 'toggles h2 tag off again');
-});
-
 test('toolbar buttons can be active', function(assert) {
   let text = 'abc';
   this.set('mobiledoc', simpleMobileDoc(text));


### PR DESCRIPTION
This has been deprecated since v0.3.1.