### PR TITLE
Use inputModeDidChange and postDidChange hooks

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -231,15 +231,15 @@ export default Component.extend({
         Ember.run.end();
       }
     });
-    editor.on('update', () => {
+    editor.postDidChange(() => {
       Ember.run.join(() => {
-        this.editorUpdated(editor);
+        this.postDidChange(editor);
       });
     });
-    editor.cursorDidChange(() => {
+    editor.inputModeDidChange(() => {
       if (this.isDestroyed) { return; }
       Ember.run.join(() => {
-        this.cursorDidChange(editor);
+        this.inputModeDidChange(editor);
       });
     });
     if (this.get('isEditingDisabled')) {
@@ -262,21 +262,21 @@ export default Component.extend({
     editor.destroy();
   },
 
-  editorUpdated(editor) {
+  postDidChange(editor) {
     let serializeVersion = this.get('serializeVersion');
     let updatedMobileDoc = editor.serialize(serializeVersion);
     this._localMobiledoc = updatedMobileDoc;
     this.sendAction('on-change', updatedMobileDoc);
   },
 
-  cursorDidChange(editor) {
-    const markupTags = arrayToMap(editor.markupsInSelection, 'tagName');
+  inputModeDidChange(editor) {
+    const markupTags = arrayToMap(editor.activeMarkups, 'tagName');
     const sectionTags = arrayToMap(editor.activeSections, 'tagName');
 
     this.set('activeMarkupTagNames', markupTags);
     this.set('activeSectionTagNames', sectionTags);
 
-    let isCursorOffEditor = !this.get('editor').cursor.offsets.head.section;
+    let isCursorOffEditor = !this.get('editor').hasCursor();
     if (!isCursorOffEditor && !this._ignoreCursorDidChange) {
       this.set('linkOffsets', null);
     } else {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4",
-    "mobiledoc-kit": "^0.9.0"
+    "mobiledoc-kit": "0.9.2-beta.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/helpers/move-cursor-to.js
+++ b/tests/helpers/move-cursor-to.js
@@ -1,3 +1,8 @@
+/**
+ * Move the cursor to the given selector.
+ * This does *not* inform the editor that the cursor has changed.
+ * `Editor#selectRange` should be preferred.
+ */
 export default function moveCursorTo(context, selector) {
   let element = context.$(selector);
   if (!element.length) {


### PR DESCRIPTION
Update mobiledoc-kit and use new `postDidChange` and `inputModeDidChange` hooks (instead of `on('update')` and `cursorDidChange`). See https://github.com/bustlelabs/mobiledoc-kit/pull/357