### PR TITLE
Deprecate createListSection. Use toggleSection instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ Additionally `editor` provides the following actions:
 
 * `toggleMarkup`, toggling the passed markup tag name in the current selection.
 * `toggleSection`, toggling the passed section tag name in the current
-  selection.
+  selection. Pass a string tagName as an argument. Possible valid values: "h1", "h2",
+   "p", "blockquote". To toggle to-from a list section pass "ul" or "ol".
 * `toggleLink`, toggling the linking of a selection. The user will be prompted
    for a URL if required.
 * `addCard`, passed a card name and payload will add that card at the end of the post.
 * `addCardInEditMode`, passed a card name and payload will add that card at the end of
   a post and render it in "edit" mode initially.
-* `createListSection`, changing selected content into list items.
+* [Deprecated] `createListSection`, changing selected content into list items.
 
 The `editor` object is often used indirectly by passing it to other
 components. For example:

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -72,33 +72,17 @@ export default Component.extend({
   actions: {
     toggleMarkup(markupTagName) {
       let editor = this.get('editor');
-      editor.run(postEditor => postEditor.toggleMarkup(markupTagName));
+      editor.toggleMarkup(markupTagName);
     },
 
-    toggleSection(newTagName) {
+    toggleSection(sectionTagName) {
       let editor = this.get('editor');
-      editor.run(postEditor => postEditor.toggleSection(newTagName));
+      editor.toggleSection(sectionTagName);
     },
 
     createListSection(tagName) {
-      const editor = this.get('editor');
-      const section = editor.activeSections[0];
-      if (!section) { return; }
-
-      // can only convert a section *into* an li, do nothing to
-      // sections that are already li sections
-      if (section.tagName === 'li') { return; }
-
-      const listItem = editor.run(postEditor => {
-        const { builder } = postEditor;
-        const listItem = builder.createListItem();
-        const listSection = builder.createListSection(tagName, [listItem]);
-        section.markers.forEach(m => listItem.markers.append(m.clone()));
-        postEditor.replaceSection(section, listSection);
-        return listItem;
-      });
-
-      editor.selectSections([listItem]);
+      Ember.deprecate('[ember-mobiledoc-editor] `createListSection` is deprecated. Use `toggleSection` with "ul" or "ol" instead', false);
+      this.send('toggleSection', tagName);
     },
 
     addCard(cardName, payload={}) {


### PR DESCRIPTION
`toggleSection` does the same thing, and it does it more completely (`createListSection` only creates a list; it cannot un-create one).