### PR TITLE
[BUGFIX] Ensure ol/ul buttons have correct active state

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -19,12 +19,12 @@ const EMPTY_MOBILEDOC = {
   sections: []
 };
 
-function arrayToMap(array, propertyName) {
+function arrayToMap(array) {
   let map = Object.create(null);
-  array.forEach(item => {
-    if (item[propertyName]) {
-      item = `is${capitalize(camelize(item[propertyName]))}`;
-      map[item] = true;
+  array.forEach(key => {
+    if (key) { // skip undefined/falsy key values
+      key = `is${capitalize(camelize(key))}`;
+      map[key] = true;
     }
   });
   return map;
@@ -244,8 +244,14 @@ export default Component.extend({
   },
 
   inputModeDidChange(editor) {
-    const markupTags = arrayToMap(editor.activeMarkups, 'tagName');
-    const sectionTags = arrayToMap(editor.activeSections, 'tagName');
+    const markupTags = arrayToMap(editor.activeMarkups.map(m => m.tagName));
+    // editor.activeSections are leaf sections.
+    // Map parent section tag names (e.g. 'p', 'ul', 'ol') so that list buttons
+    // are updated.
+    let sectionParentTagNames = editor.activeSections.map(s => {
+      return s.isNested ? s.parent.tagName : s.tagName;
+    });
+    const sectionTags = arrayToMap(sectionParentTagNames);
 
     this.set('activeMarkupTagNames', markupTags);
     this.set('activeSectionTagNames', sectionTags);

--- a/addon/components/mobiledoc-toolbar/template.hbs
+++ b/addon/components/mobiledoc-toolbar/template.hbs
@@ -58,7 +58,7 @@
 <li class="mobiledoc-toolbar__control">
   <button
     title="List"
-    class="mobiledoc-toolbar__button"
+    class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isUl 'active'}}"
     {{action editor.toggleSection 'ul'}}>
     Unordered List
   </button>
@@ -66,7 +66,7 @@
 <li class="mobiledoc-toolbar__control">
   <button
     title="Numbered List"
-    class="mobiledoc-toolbar__button"
+    class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isOl 'active'}}"
     {{action editor.toggleSection 'ol'}}>
     Ordered List
   </button>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4",
-    "mobiledoc-kit": "0.9.2-beta.2"
+    "mobiledoc-kit": "0.9.2-beta.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/helpers/create-mobiledoc.js
+++ b/tests/helpers/create-mobiledoc.js
@@ -14,6 +14,22 @@ export function simpleMobileDoc(text) {
   };
 }
 
+export function mobiledocWithList(text, listTagName='ol') {
+  return {
+    version: MOBILEDOC_VERSION,
+    markups: [],
+    atoms: [],
+    cards: [],
+    sections: [
+      [3, listTagName, [
+        [
+          [0, [], 0, text]
+        ]
+      ]]
+    ]
+  };
+}
+
 export function mobiledocWithCard(cardName, cardPayload={}) {
   return {
     version: MOBILEDOC_VERSION,


### PR DESCRIPTION
See https://github.com/bustlelabs/mobiledoc-kit/pull/359.
Changes the `activeSectionTagNames` map to use the parent tag name
for nested sections, so that it has `isUl` and `isOl` instead of `isLi`.

Fixes #22.