### PR TITLE
Adds createComponentAtom util to use Ember.Component as atoms

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -93,6 +93,10 @@ export default Component.extend({
       this._addCard(cardName, payload);
     },
 
+    addAtom(atomName, text='', payload={}) {
+      this._addAtom(atomName, text, payload);
+    },
+
     addCardInEditMode(cardName, payload={}) {
       let editMode = true;
       this._addCard(cardName, payload, editMode);
@@ -264,9 +268,7 @@ export default Component.extend({
 
   willDestroyElement() {
     let editor = this.get('editor');
-    try {
-      editor.destroy();
-    } catch(e) {}
+    editor.destroy();
   },
 
   postDidChange(editor) {
@@ -296,6 +298,21 @@ export default Component.extend({
 
   didCreateEditor(editor) {
     this.sendAction(DID_CREATE_EDITOR_ACTION, editor);
+  },
+
+  _addAtom(atomName, text, payload) {
+    let editor = this.get('editor');
+    if (!editor.hasCursor()) { return; }
+
+    let { range } = editor;
+    editor.run(postEditor => {
+      let atom = editor.builder.createAtom(atomName, text, payload);
+      let position = editor.range.head;
+      if (!range.isCollapsed) {
+        position = postEditor.deleteRange(range);
+      }
+      postEditor.insertMarkers(position, [atom]);
+    });
   },
 
   _addCard(cardName, payload, editMode=false) {

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -6,10 +6,13 @@ import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 let { computed, Component } = Ember;
 let { capitalize, camelize } = Ember.String;
 
-export const ADD_HOOK = 'addComponent';
-export const REMOVE_HOOK = 'removeComponent';
+export const ADD_CARD_HOOK = 'addComponent';
+export const REMOVE_CARD_HOOK = 'removeComponent';
+export const ADD_ATOM_HOOK = 'addAtomComponent';
+export const REMOVE_ATOM_HOOK = 'removeAtomComponent';
 export const WILL_CREATE_EDITOR_ACTION = 'will-create-editor';
 export const DID_CREATE_EDITOR_ACTION = 'did-create-editor';
+
 const EDITOR_CARD_SUFFIX = '-editor';
 const EMPTY_MOBILEDOC = {
   version: MOBILEDOC_VERSION,
@@ -63,6 +66,7 @@ export default Component.extend({
       this.set('mobiledoc', mobiledoc);
     }
     this.set('componentCards', Ember.A([]));
+    this.set('componentAtoms', Ember.A([]));
     this.set('linkOffsets', null);
     this.set('activeMarkupTagNames', {});
     this.set('activeSectionTagNames', {});
@@ -154,7 +158,7 @@ export default Component.extend({
     let editorOptions = this.get('editorOptions');
     editorOptions.mobiledoc = mobiledoc;
     editorOptions.cardOptions = {
-      [ADD_HOOK]: ({env, options, payload}, isEditing=false) => {
+      [ADD_CARD_HOOK]: ({env, options, payload}, isEditing=false) => {
         let cardId = Ember.uuid();
         let cardName = env.name;
         if (isEditing) {
@@ -180,8 +184,35 @@ export default Component.extend({
         });
         return { card, element };
       },
-      [REMOVE_HOOK]: (card) => {
+      [ADD_ATOM_HOOK]: ({env, options, payload, value}) => {
+        let atomId = Ember.uuid();
+        let atomName = env.name;
+        let destinationElementId = `mobiledoc-editor-atom-${atomId}`;
+        let element = document.createElement('span');
+        element.id = destinationElementId;
+
+        // The data must be copied to avoid sharing the reference
+        payload = Ember.copy(payload, true);
+
+        let atom = Ember.Object.create({
+          destinationElementId,
+          atomName,
+          payload,
+          value,
+          callbacks: env,
+          editor,
+          postModel: env.postModel
+        });
+        Ember.run.schedule('afterRender', () => {
+          this.get('componentAtoms').pushObject(atom);
+        });
+        return { atom, element };
+      },
+      [REMOVE_CARD_HOOK]: (card) => {
         this.get('componentCards').removeObject(card);
+      },
+      [REMOVE_ATOM_HOOK]: (atom) => {
+        this.get('componentAtoms').removeObject(atom);
       }
     };
     editor = new Editor(editorOptions);
@@ -233,7 +264,9 @@ export default Component.extend({
 
   willDestroyElement() {
     let editor = this.get('editor');
-    editor.destroy();
+    try {
+      editor.destroy();
+    } catch(e) {}
   },
 
   postDidChange(editor) {

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -5,6 +5,7 @@
   toggleMarkup=(action 'toggleMarkup')
   toggleLink=(action 'toggleLink')
   addCard=(action 'addCard')
+  addAtom=(action 'addAtom')
   addCardInEditMode=(action 'addCardInEditMode')
   toggleSection=(action 'toggleSection')
   createListSection=(action 'createListSection')
@@ -25,7 +26,7 @@
 {{#each componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
     {{! LEGACY: Payload is passed as the legacy "data" attr below. This
-        should be removed before 1.0 }}
+        is deprecated and should be removed before 1.0 }}
     {{component card.cardName
         editor=editor
         postModel=card.postModel

--- a/addon/components/mobiledoc-editor/template.hbs
+++ b/addon/components/mobiledoc-editor/template.hbs
@@ -39,3 +39,14 @@
         removeCard=(action card.env.remove)}}
   {{/ember-wormhole}}
 {{/each}}
+
+{{#each componentAtoms as |atom|}}
+  {{#ember-wormhole to=atom.destinationElementId}}
+    {{component atom.atomName
+        editor=editor
+        postModel=atom.postModel
+        atomName=atom.atomName
+        payload=atom.payload
+        value=atom.value}}
+  {{/ember-wormhole}}
+{{/each}}

--- a/addon/utils/create-component-atom.js
+++ b/addon/utils/create-component-atom.js
@@ -1,0 +1,31 @@
+const RENDER_TYPE = 'dom';
+
+import { ADD_ATOM_HOOK, REMOVE_ATOM_HOOK } from '../components/mobiledoc-editor/component';
+
+function renderFallback() {
+  let element = document.createElement('span');
+  element.innerHTML = '[placeholder for Ember atom]';
+  return element;
+}
+
+export default function createComponentAtom(name) {
+
+  return {
+    name,
+    type: RENDER_TYPE,
+    render(atomArg) {
+      let {env, options} = atomArg;
+      if (!options[ADD_ATOM_HOOK]) {
+        return renderFallback();
+      }
+
+      let { atom, element } = options[ADD_ATOM_HOOK](atomArg);
+      let { onTeardown } = env;
+
+      onTeardown(() => options[REMOVE_ATOM_HOOK](atom));
+
+      return element;
+    }
+  };
+
+}

--- a/addon/utils/create-component-card.js
+++ b/addon/utils/create-component-card.js
@@ -1,6 +1,6 @@
 const RENDER_TYPE = 'dom';
 
-import { ADD_HOOK, REMOVE_HOOK } from '../components/mobiledoc-editor/component';
+import { ADD_CARD_HOOK, REMOVE_CARD_HOOK } from '../components/mobiledoc-editor/component';
 
 function renderFallback() {
   let element = document.createElement('div');
@@ -15,28 +15,28 @@ export default function createComponentCard(name) {
     type: RENDER_TYPE,
     render(cardArg) {
       let {env, options} = cardArg;
-      if (!options[ADD_HOOK]) {
+      if (!options[ADD_CARD_HOOK]) {
         return renderFallback();
       }
 
-      let { card, element } = options[ADD_HOOK](cardArg);
+      let { card, element } = options[ADD_CARD_HOOK](cardArg);
       let { onTeardown } = env;
 
-      onTeardown(() => options[REMOVE_HOOK](card));
+      onTeardown(() => options[REMOVE_CARD_HOOK](card));
 
       return element;
     },
     edit(cardArg) {
       let {env, options} = cardArg;
-      if (!options[ADD_HOOK]) {
+      if (!options[ADD_CARD_HOOK]) {
         return renderFallback();
       }
 
       let isEditing = true;
-      let { card, element } = options[ADD_HOOK](cardArg, isEditing);
+      let { card, element } = options[ADD_CARD_HOOK](cardArg, isEditing);
       let { onTeardown } = env;
 
-      onTeardown(() => options[REMOVE_HOOK](card));
+      onTeardown(() => options[REMOVE_CARD_HOOK](card));
 
       return element;
     }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0",
     "ember-wormhole": "^0.3.4",
-    "mobiledoc-kit": "^0.9.2"
+    "mobiledoc-kit": "0.9.4-beta.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
 import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+let resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,9 +3,9 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var application;
+  let application;
 
-  var attributes = Ember.merge({}, config.APP);
+  let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -15,10 +15,30 @@ import {
   simpleMobileDoc, linkMobileDoc, mobiledocWithCard
 } from '../../../helpers/create-mobiledoc';
 
-const COMPONENT_CARD_EXPECTED_PROPS = ['env', 'editCard', 'saveCard', 'cancelCard', 'removeCard'];
+let { Component } = Ember;
+
+const COMPONENT_CARD_EXPECTED_PROPS = ['env', 'editCard', 'saveCard', 'cancelCard', 'removeCard', 'postModel'];
 
 moduleForComponent('mobiledoc-editor', 'Integration | Component | mobiledoc editor', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.registerAtomComponent = (atomName, template, componentClass=Component.extend({tagName: 'span'})) => {
+      this.registry.register(`component:${atomName}`, componentClass);
+      this.registry.register(`template:components/${atomName}`, template);
+      return createComponentAtom(atomName);
+    };
+    this.registerCardComponent = (cardName, template, componentClass=Component.extend()) => {
+      this.registry.register(`component:${cardName}`, componentClass);
+      this.registry.register(`template:components/${cardName}`, template);
+      return createComponentCard(cardName);
+    };
+    this.registerCardComponentWithEditor = (cardName, template, componentClass, editorTemplate, editorClass=Component.extend()) => {
+      let card = this.registerCardComponent(cardName, template, componentClass);
+      this.registry.register(`component:${cardName}-editor`, editorClass);
+      this.registry.register(`template:components/${cardName}-editor`, editorTemplate);
+      return card;
+    };
+  }
 });
 
 test('it boots the mobiledoc editor', function(assert) {
@@ -115,16 +135,13 @@ test('wraps component-card adding in runloop correctly', function(assert) {
 
   this.set('mobiledoc', mobiledoc);
   this.on('didCreateEditor', (_editor) => editor = _editor);
-  this.registry.register('template:components/demo-card', hbs`
+  let card = this.registerCardComponent('demo-card', hbs`
     <div id="demo-card">demo-card</div>
-   `);
-  this.set('cards', [createComponentCard('demo-card')]);
-  this.set('mobiledoc', simpleMobileDoc(''));
+  `);
+  this.set('cards', [card]);
+  this.set('mobiledoc', simpleMobileDoc());
   this.render(hbs`
-    {{#mobiledoc-editor
-              did-create-editor=(action "didCreateEditor")
-              mobiledoc=mobiledoc
-              cards=cards as |editor|}}
+    {{#mobiledoc-editor did-create-editor=(action 'didCreateEditor') mobiledoc=mobiledoc cards=cards as |editor|}}
     {{/mobiledoc-editor}}
   `);
 
@@ -412,36 +429,16 @@ test('it adds a component in display mode to the mobiledoc editor', function(ass
   assert.ok(this.$(`#demo-card-editor`).length, 'Card changed to edit mode');
 });
 
-test('exposes the `postModel` on the card component', function(assert) {
-  assert.expect(2);
-  this.registry.register('component:demo-card', Ember.Component.extend({
-    init() {
-      this._super(...arguments);
-      assert.ok(!!this.get('postModel'), 'card is passed postModel');
-    }
-  }));
-  this.registry.register('template:components/demo-card',
-                         hbs`<div id="demo-card"></div>`);
-  this.set('cards', [createComponentCard('demo-card')]);
-  this.render(hbs`
-    {{#mobiledoc-editor cards=cards as |editor|}}
-      <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
-    {{/mobiledoc-editor}}
-  `);
-
-  this.$('button#add-card').click();
-  assert.ok(this.$(`#demo-card`).length, 'Card added in display mode');
-});
-
 test('it adds a card and removes an active blank section', function(assert) {
   assert.expect(4);
 
-  this.registry.register('template:components/demo-card', hbs`
+  let editor;
+  let card = this.registerCardComponent('demo-card', hbs`
     <div id="demo-card"><button id='edit-card' {{action editCard}}></button></div>
    `);
-  this.set('cards', [ createComponentCard('demo-card') ]);
-  this.set('mobiledoc', simpleMobileDoc(''));
-  this.on('didCreateEditor', (editor) => { this.editor = editor; });
+  this.set('cards', [card]);
+  this.set('mobiledoc', simpleMobileDoc());
+  this.on('didCreateEditor', (_editor) => editor = _editor);
   this.render(hbs`
     {{#mobiledoc-editor mobiledoc=mobiledoc cards=cards did-create-editor=(action "didCreateEditor") as |editor|}}
       <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
@@ -450,7 +447,7 @@ test('it adds a card and removes an active blank section', function(assert) {
 
   assert.equal(this.$('.mobiledoc-editor p').length, 1, 'blank section exists');
   assert.equal(this.$('#demo-card').length, 0, 'no card section exists');
-  this.editor.selectRange(new MobiledocKit.Range(this.editor.post.headPosition()));
+  editor.selectRange(new MobiledocKit.Range(editor.post.headPosition()));
   this.$('button#add-card').click();
 
   assert.equal(this.$('.mobiledoc-editor p').length, 0, 'no blank section');
@@ -459,26 +456,21 @@ test('it adds a card and removes an active blank section', function(assert) {
 
 test('it adds a card and focuses the cursor at the end of the card', function(assert) {
   assert.expect(6);
-  this.registry.register('template:components/demo-card', hbs`
+
+  let card = this.registerCardComponent('demo-card', hbs`
     <div id="demo-card"><button id='edit-card' {{action editCard}}></button></div>
    `);
-  this.set('cards', [
-    createComponentCard('demo-card')
-  ]);
+  this.set('cards', [card]);
   let editor;
-  this.on('expose-editor', (hash) => {
-    editor = hash.editor;
-  });
-  this.set('mobiledoc', simpleMobileDoc(''));
+  this.on('didCreateEditor', (_editor) => editor = _editor);
+  this.set('mobiledoc', simpleMobileDoc());
   this.render(hbs`
-    {{#mobiledoc-editor mobiledoc=mobiledoc cards=cards as |editor|}}
+    {{#mobiledoc-editor did-create-editor=(action 'didCreateEditor') mobiledoc=mobiledoc cards=cards as |editor|}}
       <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
-      <button id='get-editor' {{action 'expose-editor' editor}}></button>
     {{/mobiledoc-editor}}
   `);
 
   moveCursorTo(this, '.mobiledoc-editor p');
-  this.$('button#get-editor').click();
   this.$('button#add-card').click();
   assert.equal(this.$('#demo-card').length, 1, 'card section exists');
 
@@ -503,9 +495,7 @@ test('it has `addCardInEditMode` action to add card in edit mode', function(asse
 
   this.render(hbs`
     {{#mobiledoc-editor cards=cards as |editor|}}
-      <button id='add-card'
-              {{action editor.addCardInEditMode 'demo-card'}}>
-      </button>
+      <button id='add-card' {{action editor.addCardInEditMode 'demo-card'}}>Add Card</button>
     {{/mobiledoc-editor}}
   `);
 
@@ -525,9 +515,8 @@ test(`sets ${COMPONENT_CARD_EXPECTED_PROPS.join(',')} properties on card compone
       });
     }
   });
-  this.registry.register('component:demo-card', Component);
-  this.registry.register('template:components/demo-card', hbs`<div id="demo-card"></div>`);
-  this.set('cards', [createComponentCard('demo-card')]);
+  let card = this.registerCardComponent('demo-card', hbs`<div id='demo-card'></div>`, Component);
+  this.set('cards', [card]);
   this.set('mobiledoc', mobiledocWithCard('demo-card'));
 
   this.render(hbs`
@@ -545,9 +534,8 @@ test('component card `env` property exposes `isInEditor`', function(assert) {
       env = this.get('env');
     }
   });
-  this.registry.register('component:demo-card', Component);
-  this.registry.register('template:components/demo-card', hbs`<div id="demo-card"></div>`);
-  this.set('cards', [createComponentCard('demo-card')]);
+  let card = this.registerCardComponent('demo-card', hbs`<div id='demo-card'></div>`, Component);
+  this.set('cards', [card]);
   this.set('mobiledoc', mobiledocWithCard('demo-card'));
 
   this.render(hbs`
@@ -575,15 +563,14 @@ test('(deprecated) `addCard` passes `data`, breaks reference to original payload
     }
   });
 
-  this.registry.register('component:demo-card', DemoCardComponent);
-  this.registry.register('template:components/demo-card', hbs`
+  let card = this.registerCardComponent('demo-card', hbs`
     <div id="demo-card">
       {{data.foo}}
       <button id='mutate-payload' {{action 'mutatePayload'}}></button>
     </div>
-  `);
+  `, DemoCardComponent);
 
-  this.set('cards', [createComponentCard('demo-card')]);
+  this.set('cards', [card]);
   let payload = {foo: 'bar'};
   this.set('payload', payload);
 
@@ -628,15 +615,14 @@ test('`addCard` passes `payload`, breaks reference to original payload', functio
     }
   });
 
-  this.registry.register('component:demo-card', DemoCardComponent);
-  this.registry.register('template:components/demo-card', hbs`
+  let card = this.registerCardComponent('demo-card', hbs`
     <div id="demo-card">
       {{payload.foo}}
       <button id='mutate-payload' {{action 'mutatePayload'}}></button>
     </div>
-  `);
+  `, DemoCardComponent);
 
-  this.set('cards', [createComponentCard('demo-card')]);
+  this.set('cards', [card]);
   let payload = {foo: 'bar'};
   this.set('payload', payload);
 
@@ -809,33 +795,51 @@ test('#activeSectionTagNames is correct when a card is selected', function(asser
   });
 });
 
-test('wraps component-atom adding in runloop correctly', function(assert) {
-  assert.expect(3);
-  let mobiledoc = simpleMobileDoc('Howdy');
-  let editor;
-
+test('exposes `addAtom` action to add an atom', function(assert) {
+  let mobiledoc = simpleMobileDoc('howdy');
   this.set('mobiledoc', mobiledoc);
-  this.register('component:gather-editor', Ember.Component.extend({
-    didRender() {
-      editor = this.get('editor');
-    }
-  }));
-  this.registry.register('template:components/demo-atom', hbs`
-    <span id="demo-atom">demo-atom</span>
-   `);
-  this.set('atoms', [createComponentAtom('demo-atom')]);
-  this.set('mobiledoc', simpleMobileDoc(''));
+
+  this.registerAtomComponent('ember-atom', hbs`I AM AN ATOM`);
+  this.set('atoms', [createComponentAtom('ember-atom')]);
+  this.set('atomText', 'atom text');
+  this.set('atomPayload', {foo: 'bar'});
+  this.on('onChange', (_mobiledoc) => mobiledoc = _mobiledoc);
   this.render(hbs`
-    {{#mobiledoc-editor mobiledoc=mobiledoc atoms=atoms as |editor|}}
-      {{gather-editor editor=editor.editor}}
+    {{#mobiledoc-editor on-change=(action 'onChange') mobiledoc=mobiledoc atoms=atoms as |editor|}}
+      <button id='add-atom' {{action editor.addAtom 'ember-atom' atomText atomPayload}}>Add Ember Atom</button>
     {{/mobiledoc-editor}}
   `);
 
-  // Add an atom without being in a runloop
+  let button = this.$('button#add-atom');
+  assert.ok(button.length, 'precond - has button');
+  assert.ok(!this.$('span:contains(I AM AN ATOM)').length, 'precond - no atom');
+  button.click();
+
+  assert.ok(this.$('span:contains(I AM AN ATOM)').length, 'atom is added after clicking');
+
+  let atom = mobiledoc.atoms[0];
+  let [ name, text, payload ] = atom;
+  assert.equal(name, 'ember-atom', 'correct atom name in mobiledoc');
+  assert.equal(text, 'atom text', 'correct atom text in mobiledoc');
+  assert.deepEqual(payload, {foo: 'bar'}, 'correct atom payload in mobiledoc');
+});
+
+test('wraps component-atom adding in runloop correctly', function(assert) {
+  assert.expect(3);
+  let editor;
+
+  this.on('didCreateEditor', (_editor) => editor = _editor);
+  let atom = this.registerAtomComponent('demo-atom', hbs`<span id='demo-atom'>demo-atom</span>`);
+  this.set('atoms', [atom]);
+  this.set('mobiledoc', simpleMobileDoc());
+  this.render(hbs`
+    {{#mobiledoc-editor did-create-editor=(action 'didCreateEditor') mobiledoc=mobiledoc atoms=atoms as |editor|}}
+    {{/mobiledoc-editor}}
+  `);
+
   assert.ok(!Ember.run.currentRunLoop, 'precond - no run loop');
   editor.run((postEditor) => {
-    moveCursorTo(this, 'p:first');
-    let position = editor.cursor.offsets.head;
+    let position = editor.range.head;
     let atom = postEditor.builder.createAtom('demo-atom', 'value', {});
     postEditor.insertMarkers(position, [atom]);
   });
@@ -859,10 +863,11 @@ test('throws on unknown atom when `unknownAtomHandler` is not passed', function(
     ]
   });
   this.set('unknownAtomHandler', undefined);
+  this.set('atoms', []);
 
   assert.throws(() => {
     this.render(hbs`
-      {{#mobiledoc-editor mobiledoc=mobiledoc
+      {{#mobiledoc-editor mobiledoc=mobiledoc atoms=atoms
                 options=(hash unknownAtomHandler=unknownAtomHandler) as |editor|}}
       {{/mobiledoc-editor}}
     `);
@@ -894,8 +899,9 @@ test('calls `unknownAtomHandler` when it renders an unknown atom', function(asse
     ]
   });
 
+  this.set('atoms', []);
   this.render(hbs`
-    {{#mobiledoc-editor mobiledoc=mobiledoc
+    {{#mobiledoc-editor mobiledoc=mobiledoc atoms=atoms
               options=(hash unknownAtomHandler=unknownAtomHandler) as |editor|}}
     {{/mobiledoc-editor}}
   `);

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import { selectRange } from 'dummy/tests/helpers/selection';
 import hbs from 'htmlbars-inline-precompile';
 import createComponentCard from 'ember-mobiledoc-editor/utils/create-component-card';
+import createComponentAtom from 'ember-mobiledoc-editor/utils/create-component-atom';
 import moveCursorTo from '../../../helpers/move-cursor-to';
 import simulateMouseup from '../../../helpers/simulate-mouse-up';
 import Ember from 'ember';
@@ -806,4 +807,96 @@ test('#activeSectionTagNames is correct when a card is selected', function(asser
     assert.ok(this.$('#not-p').length, 'is not p');
     done();
   });
+});
+
+test('wraps component-atom adding in runloop correctly', function(assert) {
+  assert.expect(3);
+  let mobiledoc = simpleMobileDoc('Howdy');
+  let editor;
+
+  this.set('mobiledoc', mobiledoc);
+  this.register('component:gather-editor', Ember.Component.extend({
+    didRender() {
+      editor = this.get('editor');
+    }
+  }));
+  this.registry.register('template:components/demo-atom', hbs`
+    <span id="demo-atom">demo-atom</span>
+   `);
+  this.set('atoms', [createComponentAtom('demo-atom')]);
+  this.set('mobiledoc', simpleMobileDoc(''));
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=mobiledoc atoms=atoms as |editor|}}
+      {{gather-editor editor=editor.editor}}
+    {{/mobiledoc-editor}}
+  `);
+
+  // Add an atom without being in a runloop
+  assert.ok(!Ember.run.currentRunLoop, 'precond - no run loop');
+  editor.run((postEditor) => {
+    moveCursorTo(this, 'p:first');
+    let position = editor.cursor.offsets.head;
+    let atom = postEditor.builder.createAtom('demo-atom', 'value', {});
+    postEditor.insertMarkers(position, [atom]);
+  });
+  assert.ok(!Ember.run.currentRunLoop, 'postcond - no run loop after editor.run');
+
+  assert.ok(this.$('#demo-atom').length, 'demo atom is added');
+});
+
+test('throws on unknown atom when `unknownAtomHandler` is not passed', function(assert) {
+  this.set('mobiledoc', {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['missing-atom', 'value', {}]
+    ],
+    markups: [],
+    cards: [],
+    sections: [
+      [1, 'P', [
+        [1, [], 0, 0]]
+      ]
+    ]
+  });
+  this.set('unknownAtomHandler', undefined);
+
+  assert.throws(() => {
+    this.render(hbs`
+      {{#mobiledoc-editor mobiledoc=mobiledoc
+                options=(hash unknownAtomHandler=unknownAtomHandler) as |editor|}}
+      {{/mobiledoc-editor}}
+    `);
+  }, /Unknown atom "missing-atom" found.*no unknownAtomHandler/);
+});
+
+test('calls `unknownAtomHandler` when it renders an unknown atom', function(assert) {
+  assert.expect(4);
+  let expectedPayload = {};
+
+  this.set('unknownAtomHandler', ({env, value, payload}) => {
+    assert.equal(env.name, 'missing-atom', 'correct env.name');
+    assert.equal(value, 'value', 'correct name');
+    assert.ok(!!env.onTeardown, 'has onTeardown hook');
+    assert.deepEqual(payload, expectedPayload, 'has payload');
+  });
+
+  this.set('mobiledoc', {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['missing-atom', 'value', expectedPayload]
+    ],
+    markups: [],
+    cards: [],
+    sections: [
+      [1, 'P', [
+        [1, [], 0, 0]]
+      ]
+    ]
+  });
+
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=mobiledoc
+              options=(hash unknownAtomHandler=unknownAtomHandler) as |editor|}}
+    {{/mobiledoc-editor}}
+  `);
 });

--- a/tests/unit/helpers/hash-test.js
+++ b/tests/unit/helpers/hash-test.js
@@ -5,6 +5,6 @@ module('Unit | Helper | hash');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = hash([], { foo: 'bar' });
+  let result = hash([], { foo: 'bar' });
   assert.ok(result.foo, 'hash contains arguments');
 });

--- a/tests/unit/helpers/mobiledoc-titleize-test.js
+++ b/tests/unit/helpers/mobiledoc-titleize-test.js
@@ -5,6 +5,6 @@ module('Unit | Helper | mobiledoc titleize');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = mobiledocTitleize(['foo-bar']);
+  let result = mobiledocTitleize(['foo-bar']);
   assert.equal(result, 'FooBar');
 });

--- a/tests/unit/utils/create-component-atom-test.js
+++ b/tests/unit/utils/create-component-atom-test.js
@@ -1,0 +1,33 @@
+import createComponentAtom from 'ember-mobiledoc-editor/utils/create-component-atom';
+import { module, test } from 'qunit';
+import MobiledocDOMRenderer from 'mobiledoc-dom-renderer';
+
+module('Unit | Utility | create component atom');
+
+test('it creates an atom', function(assert) {
+  var result = createComponentAtom('foo-atom');
+  assert.ok(result.name === 'foo-atom' &&
+            result.type === 'dom' &&
+            typeof result.render === 'function',
+    'created a named atom'
+  );
+});
+
+test('it creates a renderable atom', function(assert) {
+  var atom = createComponentAtom('foo-atom');
+  let renderer = new MobiledocDOMRenderer({atoms: [atom]});
+
+  let {result} = renderer.render({
+    version: '0.3.0',
+    atoms: [
+      ['foo-atom', '', {}]
+    ],
+    sections: [
+      [1, 'P', [
+        [1, [], 0, 0]]
+      ]
+    ]
+  });
+
+  assert.ok(result, 'atom rendered');
+});

--- a/tests/unit/utils/create-component-atom-test.js
+++ b/tests/unit/utils/create-component-atom-test.js
@@ -5,7 +5,7 @@ import MobiledocDOMRenderer from 'mobiledoc-dom-renderer';
 module('Unit | Utility | create component atom');
 
 test('it creates an atom', function(assert) {
-  var result = createComponentAtom('foo-atom');
+  let result = createComponentAtom('foo-atom');
   assert.ok(result.name === 'foo-atom' &&
             result.type === 'dom' &&
             typeof result.render === 'function',
@@ -14,7 +14,7 @@ test('it creates an atom', function(assert) {
 });
 
 test('it creates a renderable atom', function(assert) {
-  var atom = createComponentAtom('foo-atom');
+  let atom = createComponentAtom('foo-atom');
   let renderer = new MobiledocDOMRenderer({atoms: [atom]});
 
   let {result} = renderer.render({

--- a/tests/unit/utils/create-component-card-test.js
+++ b/tests/unit/utils/create-component-card-test.js
@@ -5,7 +5,7 @@ import MobiledocDOMRenderer from 'mobiledoc-dom-renderer';
 module('Unit | Utility | create component card');
 
 test('it creates a card', function(assert) {
-  var result = createComponentCard('foo-card');
+  let result = createComponentCard('foo-card');
   assert.ok(result.name === 'foo-card' &&
             result.type === 'dom' &&
             typeof result.render === 'function' &&
@@ -15,7 +15,7 @@ test('it creates a card', function(assert) {
 });
 
 test('it creates a renderable card', function(assert) {
-  var card = createComponentCard('foo-card');
+  let card = createComponentCard('foo-card');
   let renderer = new MobiledocDOMRenderer({cards: [card]});
 
   let {result} = renderer.render({


### PR DESCRIPTION
This rebases #59.

Adds:
  * `addAtom` action on yield from {{ember-mobiledoc-editor}}
  * exports `createComponentAtom` (similar to `createComponentCard`) from 'ember-mobiledoc/utils/create-component-atom'
 
Includes some cleanup to the integration tests for clarity.