### PR TITLE
added to <button>s elements `type="button"` to avoid accessibility problems

### DIFF
--- a/addon/components/mobiledoc-link-button/component.js
+++ b/addon/components/mobiledoc-link-button/component.js
@@ -6,7 +6,9 @@ let { computed, Component } = Ember;
 export default Component.extend({
   tagName: 'button',
   layout,
+  attributeBindings: ['type'],
   classNameBindings: ['isActive:active'],
+  type: 'button',
   isActive: computed.bool('editor.activeMarkupTagNames.isA'),
   click() {
     let editor = this.get('editor');

--- a/addon/components/mobiledoc-markup-button/component.js
+++ b/addon/components/mobiledoc-markup-button/component.js
@@ -7,7 +7,9 @@ let { computed, observer, defineProperty, Component } = Ember;
 export default Component.extend({
   tagName: 'button',
   layout,
+  attributeBindings: ['type'],
   classNameBindings: ['isActive:active'],
+  type: 'button',
   init() {
     this._super(...arguments);
     this._updateIsActiveCP();

--- a/addon/components/mobiledoc-section-button/component.js
+++ b/addon/components/mobiledoc-section-button/component.js
@@ -7,7 +7,9 @@ let { computed, observer, defineProperty, Component } = Ember;
 export default Component.extend({
   tagName: 'button',
   layout,
+  attributeBindings: ['type'],
   classNameBindings: ['isActive:active'],
+  type: 'button',
   init() {
     this._super(...arguments);
     this._updateIsActiveCP();

--- a/addon/components/mobiledoc-toolbar/template.hbs
+++ b/addon/components/mobiledoc-toolbar/template.hbs
@@ -1,5 +1,6 @@
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Bold"
     class="mobiledoc-toolbar__button {{if editor.activeMarkupTagNames.isStrong 'active'}}"
     {{action editor.toggleMarkup 'strong'}}>
@@ -8,6 +9,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Italic"
     class="mobiledoc-toolbar__button {{if editor.activeMarkupTagNames.isEm 'active'}}"
     {{action editor.toggleMarkup 'em'}}>
@@ -16,6 +18,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Link"
     class="mobiledoc-toolbar__button {{if editor.activeMarkupTagNames.isA 'active'}}"
     {{action editor.toggleLink}}>
@@ -24,6 +27,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Heading"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isH1 'active'}}"
     {{action editor.toggleSection 'h1'}}>
@@ -32,6 +36,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Subheading"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isH2 'active'}}"
     {{action editor.toggleSection 'h2'}}>
@@ -40,6 +45,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Block Quote"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isBlockquote 'active'}}"
     {{action editor.toggleSection 'blockquote'}}>
@@ -49,6 +55,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Pull Quote"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isPullQuote 'active'}}"
     {{action editor.toggleSection 'pull-quote'}}>
@@ -57,6 +64,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="List"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isUl 'active'}}"
     {{action editor.toggleSection 'ul'}}>
@@ -65,6 +73,7 @@
 </li>
 <li class="mobiledoc-toolbar__control">
   <button
+    type="button"
     title="Numbered List"
     class="mobiledoc-toolbar__button {{if editor.activeSectionTagNames.isOl 'active'}}"
     {{action editor.toggleSection 'ol'}}>


### PR DESCRIPTION
it can also prevent some edge cases of page refresh since the default `type` of `<button>` element is `submit`