### PR TITLE
chore(npm): Use "version" script instead of "postversion"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall",
     "update-changelog": "conventional-changelog -i CHANGELOG.md -r 0 -s",
-    "postversion": "npm run update-changelog && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "npm run update-changelog && git add CHANGELOG.md"
   },
   "repository": "bustlelabs/ember-mobiledoc-editor",
   "engines": {


### PR DESCRIPTION
Using postversion was messing up the git tags by changing the sha of the
commit they initially pointed to.

See also https://github.com/bustlelabs/mobiledoc-kit/pull/448