### PR TITLE
Make mobiledoc-dom-renderer a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-wormhole": "^0.5.0",
     "mobiledoc-kit": "^0.10.14",
-    "mobiledoc-dom-renderer": "^0.5.4"
+    "mobiledoc-dom-renderer": "^0.6.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-wormhole": "^0.5.0",
-    "mobiledoc-kit": "^0.10.14"
+    "mobiledoc-kit": "^0.10.14",
+    "mobiledoc-dom-renderer": "^0.5.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -46,8 +47,7 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "^2.12.0-beta.1",
-    "loader.js": "^4.1.0",
-    "mobiledoc-dom-renderer": "^0.5.4"
+    "loader.js": "^4.1.0"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
It is used by index.js so it should be a dep, not a devDep