### PR TITLE
Use TestAdapter to ensure render errors are thrown

### DIFF
--- a/tests/helpers/create-throwing-adapter.js
+++ b/tests/helpers/create-throwing-adapter.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import { QUnitAdapter } from 'ember-qunit';
+
+/**
+ * Creates a TestAdapter that will throw when an exception is encountered.
+ * Before Ember 2.11, errors that occur in tests during `this.render` were thrown
+ * and catchable (and therefore testable using `assert.throws`), but
+ * in https://github.com/emberjs/ember.js/pull/14898 this changed and we need
+ * to override the Test Adapter's exception handler to rethrow the error.
+ *
+ * This file and any references can be removed if the Ember Test Adapter's
+ * error-handling behavior changes in the future.
+ */
+
+const ThrowingAdapter = QUnitAdapter.extend({
+  exception(error) {
+    // rethrow error
+    throw error;
+  }
+});
+
+export function setup(context) {
+	let origTestAdapter = Ember.Test.adapter;
+  context.__originalTestAdapter = origTestAdapter;
+
+  Ember.run(() => { Ember.Test.adapter = ThrowingAdapter.create(); });
+}
+
+export function teardown(context) {
+  if (context.__originalTestAdapter) {
+    Ember.run(() => {
+      context.__originalTestAdapter.destroy();
+      delete context.__originalTestAdapter;
+
+      Ember.Test.adapter = QUnitAdapter.create();
+    });
+  }
+}

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -14,6 +14,10 @@ import {
 } from '../../../helpers/create-mobiledoc';
 import wait from 'ember-test-helpers/wait';
 import $ from 'jquery';
+import {
+  setup as setupThrowingAdapter,
+  teardown as teardownThrowingAdapter
+} from '../../../helpers/create-throwing-adapter';
 
 let { Component } = Ember;
 
@@ -40,6 +44,10 @@ moduleForComponent('mobiledoc-editor', 'Integration | Component | mobiledoc edit
       this.registry.register(`template:components/${cardName}-editor`, editorTemplate);
       return card;
     };
+  },
+
+  afterEach() {
+    teardownThrowingAdapter(this);
   }
 });
 
@@ -750,6 +758,9 @@ test('`addCard` passes `payload`, breaks reference to original payload', functio
 });
 
 test('throws on unknown card when `unknownCardHandler` is not passed', function(assert) {
+  setupThrowingAdapter(this);
+
+  assert.expect(1);
   this.set('mobiledoc', {
     version: MOBILEDOC_VERSION,
     cards: [
@@ -769,7 +780,7 @@ test('throws on unknown card when `unknownCardHandler` is not passed', function(
                 options=(hash unknownCardHandler=unknownCardHandler) as |editor|}}
       {{/mobiledoc-editor}}
     `);
-  }, /Unknown card "missing-card" found.*no unknownCardHandler/);
+  }, /Unknown card "missing-card".*no unknownCardHandler/);
 });
 
 test('calls `unknownCardHandler` when it renders an unknown card', function(assert) {
@@ -965,6 +976,7 @@ test(`sets ${COMPONENT_ATOM_EXPECTED_PROPS.join(',')} properties on atom compone
 });
 
 test('throws on unknown atom when `unknownAtomHandler` is not passed', function(assert) {
+  setupThrowingAdapter(this);
   this.set('mobiledoc', {
     version: MOBILEDOC_VERSION,
     atoms: [


### PR DESCRIPTION
Uses a customized test adapter for some tests that will rethrow errors
that occur during the render cycle. This fixes a few tests that were
false-negativing. Notes on the change to Ember are in https://github.com/emberjs/ember.js/pull/14898

Fixes #128