### PR TITLE
remove ember-cli-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
-    "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
This project uses `np` to do the same thing, and ember-cli-release
has a dependency on a version of `npm` that causes a
conflict with `np`: https://github.com/lytics/ember-cli-release/issues/62