### PR TITLE
Drop @ember/polyfills assign in favor of Object.assign

### DIFF
--- a/addon/utils/polyfill-assign.js
+++ b/addon/utils/polyfill-assign.js
@@ -1,5 +1,1 @@
-import { assign, merge } from '@ember/polyfills';
-
-let polyfilledAssign = assign || merge;
-
-export default polyfilledAssign;
+export default Object.assign;


### PR DESCRIPTION
## Summary

`@ember/polyfills` was deprecated in Ember 4.x and **removed** in Ember 5.x. The `addon/utils/polyfill-assign.js` utility was a fallback for old Ember versions that predate the native `assign` export — `Object.assign` is a drop-in replacement.

Two call sites use the export (`addon/components/mobiledoc-editor/component.js` lines 80 and 292) and both invoke it as the standard `assign(target, ...sources)` shape, so no consumer changes are needed.

## Why now

Under Ember 4.x, every editor render currently fires the `ember-polyfills.deprecate-assign` deprecation. Apps with deprecation-as-error CI (we just turned this on across our monorepo) fail any test that mounts the editor. Under Ember 5.x, the import resolves to nothing and the editor breaks entirely.

This change unblocks consumers preparing for Ember 5 without losing compatibility with older Ember (Object.assign has been universally available since long before the lowest supported Ember version).

## Test plan

- [x] Diff is one file: `addon/utils/polyfill-assign.js` body now just `export default Object.assign;`.
- [x] No remaining `@ember/polyfills` references in `addon/` or `app/`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)