### PR TITLE
bump Node to 20.x and actions/* to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -37,10 +37,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -64,11 +64,11 @@ jobs:
           - embroider-optimized
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/addon/components/tether-to-selection/component.js
+++ b/addon/components/tether-to-selection/component.js
@@ -6,7 +6,7 @@ import { schedule } from '@ember/runloop';
 import { assert } from '@ember/debug';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 const DIALOG_MARGIN = 16;
 


### PR DESCRIPTION
## Summary

Two related bumps to get CI green:

### 1. Node + actions bumps (commit 1)

Floating-dependency installs now pull transitive deps that require Node 20+ (`mktemp@2.0.2`, modern `execa`), and the 14.x / 16.x CI runners fail every job with either:

```
error mktemp@2.0.2: Expected version "20 || 22 || 24". Got "16.20.2"
```

or:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../testem/.../execa/index.js
```

All three jobs (`test`, `floating`, `try-scenarios`) bumped to Node 20.x (current LTS). `actions/checkout` and `actions/setup-node` bumped from v3 to v4 (v3 has been deprecated since 2024).

### 2. `htmlSafe` import path (commit 2)

After the Node bump, the `floating` and older-Ember scenarios surfaced a separate failure:

```
Uncaught Error: htmlSafe is not implemented in the `@ember/string` package.
Please import from `@ember/template` instead.
```

`@ember/string@4.x` removed `htmlSafe` (it has been canonically exported from `@ember/template` since Ember 3.x). Single import site fixed in `addon/components/tether-to-selection/component.js`.

## Test plan

- [x] All three jobs reference Node 20.x.
- [x] All `actions/checkout` and `actions/setup-node` references are v4.
- [x] No remaining `htmlSafe` imports from `@ember/string`.
- [ ] CI green (or as green as it gets — `embroider-safe` has a separate preexisting `'VERSION' (imported as 'MOBILEDOC_KIT_VERSION') was not found in 'mobiledoc-kit'` regression that is out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)