### PR TITLE
Bump engines.node and volta.node to Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpack": "5"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": ">= 20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -110,7 +110,7 @@
     }
   },
   "volta": {
-    "node": "12.22.12",
+    "node": "20.19.1",
     "yarn": "1.22.19"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #223. CI is on Node 20.x, but `package.json` still advertises `engines.node: 12.* || 14.* || >= 16` and pins `volta.node: 12.22.12` for contributors — both versions that CI just proved don't work against modern transitive deps (`mktemp`, `execa`).

- `engines.node`: `12.* || 14.* || >= 16` → `>= 20`
- `volta.node`: `12.22.12` → `20.19.1` (matches CI)
- `volta.yarn`: unchanged

## Test plan

- [x] `engines.node` and `volta.node` match CI.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)