### PR TITLE
Add ember-try scenarios for Ember 4.12 LTS, 5.12 LTS, and 6.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
         try-scenario:
           - ember-lts-3.24
           - ember-lts-3.28
+          - ember-lts-4.4
+          - ember-lts-4.12
+          - ember-lts-5.12
+          - ember-6.12
           - ember-classic
           - embroider-safe
           - embroider-optimized

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
           - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.12
-          - ember-lts-5.12
-          - ember-6.12
+          - ember-lts-5.12-failing
+          - ember-6.12-failing
           - ember-classic
           - embroider-safe
           - embroider-optimized

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -49,7 +49,7 @@ module.exports = async function () {
         // Needs a build-infrastructure refresh (dummy app initializer wiring
         // + webpack config) before it can pass. Surfacing regressions here
         // is still useful — allowedToFail so CI doesn't block on it.
-        name: 'ember-lts-5.12',
+        name: 'ember-lts-5.12-failing',
         npm: {
           devDependencies: {
             '@ember/string': '^4.0.0',
@@ -62,7 +62,7 @@ module.exports = async function () {
       {
         // Same story as ember-lts-5.12 — build infrastructure needs a
         // refresh before this can pass cleanly.
-        name: 'ember-6.12',
+        name: 'ember-6.12-failing',
         npm: {
           devDependencies: {
             '@ember/string': '^4.0.0',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -38,6 +38,41 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
+        // Needs a build-infrastructure refresh (dummy app initializer wiring
+        // + webpack config) before it can pass. Surfacing regressions here
+        // is still useful — allowedToFail so CI doesn't block on it.
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            '@ember/string': '^4.0.0',
+            'ember-source': '~5.12.0',
+            'ember-resolver': '^13.0.0',
+          },
+        },
+        allowedToFail: true,
+      },
+      {
+        // Same story as ember-lts-5.12 — build infrastructure needs a
+        // refresh before this can pass cleanly.
+        name: 'ember-6.12',
+        npm: {
+          devDependencies: {
+            '@ember/string': '^4.0.0',
+            'ember-source': '~6.12.0',
+            'ember-resolver': '^13.0.0',
+          },
+        },
+        allowedToFail: true,
+      },
+      {
         name: 'ember-classic',
         env: {
           EMBER_OPTIONAL_FEATURES: JSON.stringify({


### PR DESCRIPTION
## Summary

Adds three new `ember-try` scenarios and wires them into CI:

| Scenario | Overrides | Status |
| -- | -- | -- |
| `ember-lts-4.12` | `ember-source: ~4.12.0` | Passing |
| `ember-lts-5.12-failing` | `ember-source`, `@ember/string@^4`, `ember-resolver@^13` | `allowedToFail` — needs build-infra refresh |
| `ember-6.12-failing` | `ember-source`, `@ember/string@^4`, `ember-resolver@^13` | `allowedToFail` — needs build-infra refresh |

The 5.12 and 6.12 scenarios carry the `-failing` suffix so GitHub viewers don't infer Ember 5/6 compatibility from a passing-looking badge. They run in CI and will flip to the unsuffixed names once the addon is actually compatible.

Also adds `ember-lts-4.4` to the CI matrix — previously defined in `config/ember-try.js` but not actually exercised by the workflow.

## Local verification

`ember try:one ember-lts-4.12` → all scenarios succeeded.

## Why `allowedToFail` on 5.12 and 6.12

Under Ember 5+, `@ember/string` is no longer bundled with `ember-source` — it needs an explicit dependency. With that plus a current `ember-resolver`, the scenarios install, but the dummy app's build config still produces a runtime `TypeError: Cannot read properties of undefined (reading 'classify')` in an auto-registered initializer DAG — a sign that the test-harness plumbing (dummy app initializer wiring, webpack config) needs a refresh beyond what an `ember-try` scenario override can do.

Rather than block this PR on that refresh, the scenarios run as `allowedToFail` so CI surfaces regressions early. Fixing the infrastructure is worth its own PR.

## Test plan

- [x] `ember-lts-4.12` passes locally.
- [x] `ember-lts-5.12-failing` and `ember-6.12-failing` install under the scenario overrides (install succeeds; runtime still fails).
- [x] No regressions to existing scenarios.
- [ ] CI green — existing scenarios unaffected; new `allowedToFail` ones may be red but don't gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)