### PR TITLE
Make ember-lts-5.12 and ember-6.12 scenarios pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
           - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.12
-          - ember-lts-5.12-failing
-          - ember-6.12-failing
+          - ember-lts-5.12
+          - ember-6.12
           - ember-classic
           - embroider-safe
           - embroider-optimized

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## ember-mobiledoc-editor
 
 [![npm version](https://badge.fury.io/js/ember-mobiledoc-editor.svg)](https://badge.fury.io/js/ember-mobiledoc-editor)
-[![Build Status](https://travis-ci.org/bustle/ember-mobiledoc-editor.svg)](https://travis-ci.org/bustle/ember-mobiledoc-editor)
+[![CI](https://github.com/bustle/ember-mobiledoc-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/bustle/ember-mobiledoc-editor/actions/workflows/ci.yml)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-mobiledoc-editor.svg)](https://emberobserver.com/addons/ember-mobiledoc-editor)
 
 A Mobiledoc editor written using Ember.js UI components and
@@ -75,40 +75,44 @@ The component accepts these arguments:
   The action is passed the created editor instance.
   This action may be fired more than once if the component's `mobiledoc` property is set to a new value.
 
-For example, the following index route and template would log before and
+For example, the following component and template would log before and
 after creating the MobiledocKitEditor, and every time the user modified the
 mobiledoc (by typing some text, e.g.).
 
 ```javascript
-// routes/index.js
+// components/my-editor.js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Ember.Route.extend({
- ...,
- actions: {
-   mobiledocWasUpdated(updatedMobiledoc) {
-     console.log('New mobiledoc:',updatedMobiledoc);
-     // note that this action will be fired for every changed character,
-     // so you may want to debounce API calls if you are using it for
-     // an "autosave" feature.
-   },
-   willCreateEditor() {
-     console.log('about to create the editor');
-   },
-   didCreateEditor(editor) {
-     console.log('created the editor:', editor);
-   }
- }
-});
+export default class MyEditor extends Component {
+  @action
+  mobiledocWasUpdated(updatedMobiledoc) {
+    console.log('New mobiledoc:', updatedMobiledoc);
+    // note that this handler will be fired for every changed character,
+    // so you may want to debounce API calls if you are using it for
+    // an "autosave" feature.
+  }
+
+  @action
+  willCreateEditor() {
+    console.log('about to create the editor');
+  }
+
+  @action
+  didCreateEditor(editor) {
+    console.log('created the editor:', editor);
+  }
+}
 ```
 
 ```hbs
-{{! index.hbs }}
+{{! components/my-editor.hbs }}
 
-{{mobiledoc-editor
-    on-change=(action 'mobiledocWasUpdated')
-    will-create-editor=(action 'willCreateEditor')
-    did-create-editor=(action 'didCreateEditor')
-}}
+<MobiledocEditor
+  @on-change={{this.mobiledocWasUpdated}}
+  @will-create-editor={{this.willCreateEditor}}
+  @did-create-editor={{this.didCreateEditor}}
+/>
 ```
 
 Of course often you want to provide a user interface to bold text, create
@@ -294,22 +298,18 @@ components as the display and edit modes of a card. Create a list of cards
 using the `createComponentCard` helper:
 
 ```js
-import Ember from 'ember';
+import Component from '@glimmer/component';
 import createComponentCard from 'ember-mobiledoc-editor/utils/create-component-card';
 
-export default Ember.Component.extend({
-  cards: Ember.computed(function() {
-    return [
-      createComponentCard('demo-card')
-    ];
-  })
-});
+export default class MyEditor extends Component {
+  cards = [createComponentCard('demo-card')];
+}
 ```
 
 And pass that list into the `{{mobiledoc-editor}}` component:
 
 ```hbs
-{{mobiledoc-editor cards=cards}}
+<MobiledocEditor @cards={{this.cards}} />
 ```
 
 When added to the post (or loaded from a passed-in Mobiledoc), these components
@@ -341,27 +341,23 @@ ember-mobiledoc-editor comes with a handle helper for using Ember
 components as an atom. Create a list of atoms using the `createComponentAtom` helper:
 
 ```js
-import Ember from 'ember';
+import Component from '@glimmer/component';
 import createComponentAtom from 'ember-mobiledoc-editor/utils/create-component-atom';
 
-export default Ember.Component.extend({
-  atoms: Ember.computed(function() {
-    return [
-      createComponentAtom('demo-atom')
-    ];
-  })
-});
+export default class MyEditor extends Component {
+  atoms = [createComponentAtom('demo-atom')];
+}
 ```
 
 And pass that list into the `{{mobiledoc-editor}}` component:
 
 ```hbs
-{{mobiledoc-editor atoms=atoms}}
+<MobiledocEditor @atoms={{this.atoms}} />
 ```
 
 ### Editor Lifecycle Hooks
 
-Currently editor lifecycle hooks are available by available by extending the mobiledoc-editor component.
+Currently editor lifecycle hooks are available by extending the mobiledoc-editor component.
 
 ```js
 import Component from 'ember-mobiledoc-editor/components/mobiledoc-editor/component';
@@ -390,18 +386,21 @@ ember-mobiledoc-editor exposes two test helpers for use in your acceptance tests
 Example usage:
 ```javascript
 // acceptance test
-import { insertText, run } from '../../helpers/ember-mobiledoc-editor';
-import { find } from '@enber/test-helpers';
-test('visit /', function(assert) {
-  visit('/');
-  andThen(() => {
-    let editorEl = find('.mobiledoc-editor__editor');
-    return insertText(editorEl, 'here is some text');
-    /* Or:
-      return run(editorEl, (postEditor) => ...);
-    */
-  });
-  andThen(() => {
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, find } from '@ember/test-helpers';
+import { insertText, run } from '../helpers/ember-mobiledoc-editor';
+
+module('Acceptance | editor', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /', async function (assert) {
+    await visit('/');
+
+    const editorEl = find('.mobiledoc-editor__editor');
+    await insertText(editorEl, 'here is some text');
+    // Or: await run(editorEl, (postEditor) => ...);
+
     // assert text inserted, etc.
   });
 });
@@ -409,29 +408,25 @@ test('visit /', function(assert) {
 
 ### Developing ember-mobiledoc-editor
 
-Releasing a new version:
+#### Setup
 
-This README outlines the details of collaborating on this Ember addon.
-
-## Installation
-
-* `git clone <repository-url>` this repository
+* `git clone git@github.com:bustle/ember-mobiledoc-editor.git`
 * `cd ember-mobiledoc-editor`
 * `pnpm install`
 
 Run the development server:
 
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+* `pnpm start`
+* Visit the dummy app at [http://localhost:4200](http://localhost:4200).
 
-## Running Tests
+#### Running Tests
 
-* `pnpm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
+* `pnpm test` — runs lint, the current-Ember test suite, and `ember try:each` against every supported Ember version.
+* `pnpm test:ember` — runs the dummy-app test suite once.
+* `ember test --server` — dev-friendly watcher.
 
-## Building
+#### Building
 
-* `ember build`
+* `pnpm build`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -46,31 +46,22 @@ module.exports = async function () {
         },
       },
       {
-        // Needs a build-infrastructure refresh (dummy app initializer wiring
-        // + webpack config) before it can pass. Surfacing regressions here
-        // is still useful — allowedToFail so CI doesn't block on it.
-        name: 'ember-lts-5.12-failing',
+        name: 'ember-lts-5.12',
         npm: {
           devDependencies: {
-            '@ember/string': '^4.0.0',
             'ember-source': '~5.12.0',
             'ember-resolver': '^13.0.0',
           },
         },
-        allowedToFail: true,
       },
       {
-        // Same story as ember-lts-5.12 — build infrastructure needs a
-        // refresh before this can pass cleanly.
-        name: 'ember-6.12-failing',
+        name: 'ember-6.12',
         npm: {
           devDependencies: {
-            '@ember/string': '^4.0.0',
             'ember-source': '~6.12.0',
             'ember-resolver': '^13.0.0',
           },
         },
-        allowedToFail: true,
       },
       {
         name: 'ember-classic',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "version": "npm run update-changelog && git add CHANGELOG.md"
   },
   "dependencies": {
+    "@ember/string": "^3.1.1 || ^4.0.0",
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^2.4.3",
@@ -57,7 +58,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-page-title": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ember/string':
+        specifier: ^3.1.1 || ^4.0.0
+        version: 3.1.1
       broccoli-funnel:
         specifier: ^3.0.8
         version: 3.0.8
@@ -87,9 +90,6 @@ importers:
       ember-disable-prototype-extensions:
         specifier: ^1.1.3
         version: 1.1.3
-      ember-export-application-global:
-        specifier: ^2.0.1
-        version: 2.0.1
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.29.0)
@@ -2914,10 +2914,6 @@ packages:
   ember-disable-prototype-extensions@1.1.3:
     resolution: {integrity: sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==}
     engines: {node: '>= 0.10.0'}
-
-  ember-export-application-global@2.0.1:
-    resolution: {integrity: sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==}
-    engines: {node: '>= 4'}
 
   ember-load-initializers@2.1.2:
     resolution: {integrity: sha512-CYR+U/wRxLbrfYN3dh+0Tb6mFaxJKfdyz+wNql6cqTrA0BBi9k6J3AaKXj273TqvEpyyXegQFFkZEiuZdYtgJw==}
@@ -11045,8 +11041,6 @@ snapshots:
       - supports-color
 
   ember-disable-prototype-extensions@1.1.3: {}
-
-  ember-export-application-global@2.0.1: {}
 
   ember-load-initializers@2.1.2(@babel/core@7.29.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - core-js
+  - fsevents

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -3,7 +3,8 @@
 /* eslint-disable ember/no-classic-components */
 import { Promise as EmberPromise } from 'rsvp';
 import { run, _getCurrentRunLoop } from '@ember/runloop';
-import Component from '@ember/component';
+import Component, { setComponentTemplate } from '@ember/component';
+import templateOnly from '@ember/component/template-only';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -59,19 +60,13 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
-  hooks.beforeEach(function () {
     this.registerAtomComponent = (
       atomName,
       template,
       componentClass = Component.extend({ tagName: 'span' })
     ) => {
+      setComponentTemplate(template, componentClass);
       this.owner.register(`component:${atomName}`, componentClass);
-      this.owner.register(`template:components/${atomName}`, template);
       return createComponentAtom(atomName);
     };
     this.registerCardComponent = (
@@ -79,8 +74,8 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
       template,
       componentClass = Component.extend()
     ) => {
+      setComponentTemplate(template, componentClass);
       this.owner.register(`component:${cardName}`, componentClass);
-      this.owner.register(`template:components/${cardName}`, template);
       return createComponentCard(cardName);
     };
     this.registerCardComponentWithEditor = (
@@ -91,11 +86,8 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
       editorClass = Component.extend()
     ) => {
       let card = this.registerCardComponent(cardName, template, componentClass);
+      setComponentTemplate(editorTemplate, editorClass);
       this.owner.register(`component:${cardName}-editor`, editorClass);
-      this.owner.register(
-        `template:components/${cardName}-editor`,
-        editorTemplate
-      );
       return card;
     };
   });
@@ -143,12 +135,12 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     this.set('mobiledoc', simpleMobileDoc('hello'));
 
-    this.actions.willCreateEditor = () => {
+    this.willCreateEditor = () => {
       willCreateCalls++;
       assert.notOk(editor, 'calls willCreateEditor before didCreateEditor');
     };
 
-    this.actions.didCreateEditor = (editor) => {
+    this.didCreateEditor = (editor) => {
       assert.equal(
         willCreateCalls,
         1,
@@ -163,8 +155,8 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     await render(hbs`
       <MobiledocEditor @mobiledoc={{this.mobiledoc}}
-          @will-create-editor={{action "willCreateEditor"}}
-          @did-create-editor={{action "didCreateEditor"}} as |editor|>
+          @will-create-editor={{this.willCreateEditor}}
+          @did-create-editor={{this.didCreateEditor}} as |editor|>
       </MobiledocEditor>
     `);
   });
@@ -177,16 +169,17 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     let didCreateCalls = 0;
 
     this.set('mobiledoc', mobiledoc);
-    this.actions.willCreateEditor = () => willCreateCalls++;
-    this.actions.didCreateEditor = (_editor) => {
+    this.willCreateEditor = () => willCreateCalls++;
+    this.didCreateEditor = (_editor) => {
       editor = _editor;
       didCreateCalls++;
     };
+    this.updateMobiledoc = (value) => this.set('mobiledoc', value);
     await render(hbs`
       <MobiledocEditor @mobiledoc={{readonly this.mobiledoc}}
-                          @will-create-editor={{action "willCreateEditor"}}
-                          @did-create-editor={{action "didCreateEditor"}}
-                          @on-change={{action (mut this.mobiledoc)}} as |editor|>
+                          @will-create-editor={{this.willCreateEditor}}
+                          @did-create-editor={{this.didCreateEditor}}
+                          @on-change={{this.updateMobiledoc}} as |editor|>
       </MobiledocEditor>
     `);
 
@@ -207,7 +200,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     let editor;
 
     this.set('mobiledoc', mobiledoc);
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     let card = this.registerCardComponent(
       'demo-card',
       hbs`
@@ -217,7 +210,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     this.set('cards', [card]);
     this.set('mobiledoc', simpleMobileDoc());
     await render(hbs`
-      <MobiledocEditor @did-create-editor={{action 'didCreateEditor'}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
+      <MobiledocEditor @did-create-editor={{this.didCreateEditor}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
       </MobiledocEditor>
     `);
 
@@ -291,13 +284,13 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     this.set('mobiledoc', simpleMobileDoc(text));
 
     let changeEvents = [];
-    this.actions['on-change'] = (mobiledoc) => {
+    this.onChange = (mobiledoc) => {
       changeEvents.push(mobiledoc);
     };
 
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{action 'on-change'}} as |editor|>
-        <button {{action editor.toggleMarkup 'strong'}}>Bold</button>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{this.onChange}} as |editor|>
+        <button {{on 'click' (fn editor.toggleMarkup 'strong')}}>Bold</button>
       </MobiledocEditor>
     `);
     let textNode = findAll('p').find((el) =>
@@ -322,12 +315,12 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     let version;
 
-    this.actions['on-change'] = (mobiledoc) => {
+    this.onChange = (mobiledoc) => {
       version = mobiledoc.version;
     };
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @serializeVersion={{this.serializeVersion}} @on-change={{action 'on-change'}} as |editor|>
-        <button {{action editor.toggleMarkup 'strong'}}>Bold</button>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @serializeVersion={{this.serializeVersion}} @on-change={{this.onChange}} as |editor|>
+        <button {{on 'click' (fn editor.toggleMarkup 'strong')}}>Bold</button>
       </MobiledocEditor>
     `);
     let textNode = findAll('p').find((el) =>
@@ -363,10 +356,10 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     let text = 'Howdy';
     this.set('mobiledoc', simpleMobileDoc(text));
-    this.actions['on-change'] = () => onChangeCount++;
+    this.onChange = () => onChangeCount++;
     await render(hbs`
-      {{#mobiledoc-editor mobiledoc=this.mobiledoc on-change=(action 'on-change') as |editor|}}
-        <button {{action editor.toggleSection 'h2'}}>H2</button>
+      {{#mobiledoc-editor mobiledoc=this.mobiledoc on-change=this.onChange as |editor|}}
+        <button {{on 'click' (fn editor.toggleSection 'h2')}}>H2</button>
       {{/mobiledoc-editor}}
     `);
     let textNode = findAll('p').find((el) =>
@@ -396,9 +389,9 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     let text = 'Howdy';
     this.set('mobiledoc', simpleMobileDoc(text));
-    this.actions['on-change'] = () => onChangeCount++;
+    this.onChange = () => onChangeCount++;
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{action 'on-change'}} as |editor|>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{this.onChange}} as |editor|>
         <MobiledocSectionAttributeButton @editor={{editor}} @attributeName="text-align" @attributeValue="left" />
         <MobiledocSectionAttributeButton @editor={{editor}} @attributeName="text-align" @attributeValue="center" />
       </MobiledocEditor>
@@ -486,10 +479,10 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
   test('toggleLink action is no-op when nothing is selected', async function (assert) {
     assert.expect(2);
     this.set('mobiledoc', simpleMobileDoc(''));
-    this.actions.didCreateEditor = (editor) => (this._editor = editor);
+    this.didCreateEditor = (editor) => (this._editor = editor);
     await render(hbs`
-      {{#mobiledoc-editor autofocus=false mobiledoc=this.mobiledoc did-create-editor=(action 'didCreateEditor') as |editor|}}
-        <button {{action editor.toggleLink}}>Link</button>
+      {{#mobiledoc-editor autofocus=false mobiledoc=this.mobiledoc did-create-editor=this.didCreateEditor as |editor|}}
+        <button {{on 'click' editor.toggleLink}}>Link</button>
       {{/mobiledoc-editor}}
     `);
 
@@ -502,11 +495,11 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     assert.expect(2);
     let text = 'Howdy';
     this.set('mobiledoc', simpleMobileDoc(text));
-    this.actions['on-change'] = (mobiledoc) => (this._mobiledoc = mobiledoc);
-    this.actions.didCreateEditor = (editor) => (this._editor = editor);
+    this.onChange = (mobiledoc) => (this._mobiledoc = mobiledoc);
+    this.didCreateEditor = (editor) => (this._editor = editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{action 'on-change'}} @did-create-editor={{action 'didCreateEditor'}} as |editor|>
-        <button {{action editor.toggleLink}} data-test-link-button>Link</button>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{this.onChange}} @did-create-editor={{this.didCreateEditor}} as |editor|>
+        <button {{on 'click' editor.toggleLink}} data-test-link-button>Link</button>
       </MobiledocEditor>
     `);
     let { _editor: editor } = this;
@@ -539,11 +532,11 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     assert.expect(2);
     let text = 'Howdy';
     this.set('mobiledoc', linkMobileDoc(text));
-    this.actions['on-change'] = (mobiledoc) => (this._mobiledoc = mobiledoc);
-    this.actions['did-create-editor'] = (editor) => (this._editor = editor);
+    this.onChange = (mobiledoc) => (this._mobiledoc = mobiledoc);
+    this.didCreateEditor = (editor) => (this._editor = editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{action 'on-change'}} @did-create-editor={{action 'did-create-editor'}} as |editor|>
-        <button {{action editor.toggleLink}} data-test-link-button>Link</button>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @on-change={{this.onChange}} @did-create-editor={{this.didCreateEditor}} as |editor|>
+        <button {{on 'click' editor.toggleLink}} data-test-link-button>Link</button>
       </MobiledocEditor>
     `);
 
@@ -561,20 +554,26 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
   test('it adds a component in display mode to the mobiledoc editor', async function (assert) {
     assert.expect(5);
     this.owner.register(
-      'template:components/demo-card',
-      hbs`
-      <div id="demo-card"><button id='edit-card' {{action @editCard}}>CLICK ME</button></div>
-     `
+      'component:demo-card',
+      setComponentTemplate(
+        hbs`
+      <div id="demo-card"><button id='edit-card' {{on 'click' @editCard}}>CLICK ME</button></div>
+     `,
+        templateOnly()
+      )
     );
     this.owner.register(
-      'template:components/demo-card-editor',
-      hbs`<div id="demo-card-editor"></div>`
+      'component:demo-card-editor',
+      setComponentTemplate(
+        hbs`<div id="demo-card-editor"></div>`,
+        templateOnly()
+      )
     );
     this.set('cards', [createComponentCard('demo-card')]);
     this.set('mobiledoc', simpleMobileDoc());
     await render(hbs`
       <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
-        <button id='add-card' {{action editor.addCard 'demo-card'}}>Add card</button>
+        <button id='add-card' {{on 'click' (fn editor.addCard 'demo-card')}}>Add card</button>
       </MobiledocEditor>
     `);
 
@@ -596,15 +595,15 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     let card = this.registerCardComponent(
       'demo-card',
       hbs`
-      <div id="demo-card"><button id='edit-card' {{action this.editCard}}></button></div>
+      <div id="demo-card"><button id='edit-card' {{on 'click' this.editCard}}></button></div>
      `
     );
     this.set('cards', [card]);
     this.set('mobiledoc', simpleMobileDoc());
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} @did-create-editor={{action "didCreateEditor"}} as |editor|>
-        <button id='add-card' {{action editor.addCard 'demo-card'}}></button>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} @did-create-editor={{this.didCreateEditor}} as |editor|>
+        <button id='add-card' {{on 'click' (fn editor.addCard 'demo-card')}}></button>
       </MobiledocEditor>
     `);
 
@@ -625,16 +624,16 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     let card = this.registerCardComponent(
       'demo-card',
       hbs`
-      <div id="demo-card"><button id='edit-card' {{action @editCard}}>DEMO CARD</button></div>
+      <div id="demo-card"><button id='edit-card' {{on 'click' @editCard}}>DEMO CARD</button></div>
      `
     );
     this.set('cards', [card]);
     let editor;
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     this.set('mobiledoc', simpleMobileDoc());
     await render(hbs`
-      <MobiledocEditor @autofocus={{false}} @did-create-editor={{action 'didCreateEditor'}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
-        <button id='add-card' {{action editor.addCard 'demo-card'}}>ADD CARD</button>
+      <MobiledocEditor @autofocus={{false}} @did-create-editor={{this.didCreateEditor}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
+        <button id='add-card' {{on 'click' (fn editor.addCard 'demo-card')}}>ADD CARD</button>
       </MobiledocEditor>
     `);
 
@@ -676,10 +675,10 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     );
     this.set('cards', [card]);
     let editor;
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     this.set('mobiledoc', blankMobiledoc());
     await render(hbs`
-      <MobiledocEditor @did-create-editor={{action 'didCreateEditor'}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
+      <MobiledocEditor @did-create-editor={{this.didCreateEditor}} @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
       </MobiledocEditor>
     `);
 
@@ -695,19 +694,22 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
   test('it has `addCardInEditMode` action to add card in edit mode', async function (assert) {
     assert.expect(2);
     this.owner.register(
-      'template:components/demo-card',
-      hbs`<div id="demo-card"></div>`
+      'component:demo-card',
+      setComponentTemplate(hbs`<div id="demo-card"></div>`, templateOnly())
     );
     this.owner.register(
-      'template:components/demo-card-editor',
-      hbs`<div id="demo-card-editor"></div>`
+      'component:demo-card-editor',
+      setComponentTemplate(
+        hbs`<div id="demo-card-editor"></div>`,
+        templateOnly()
+      )
     );
     this.set('cards', [createComponentCard('demo-card')]);
     this.set('mobiledoc', simpleMobileDoc());
 
     await render(hbs`
       <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
-        <button id='add-card' {{action editor.addCardInEditMode 'demo-card'}}>Add Card</button>
+        <button id='add-card' {{on 'click' (fn editor.addCardInEditMode 'demo-card')}}>Add Card</button>
       </MobiledocEditor>
     `);
 
@@ -851,7 +853,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
       hbs`
       <div id="demo-card">
         {{this.data.foo}}
-        <button id='mutate-payload' {{action this.mutatePayload}}></button>
+        <button id='mutate-payload' {{on 'click' this.mutatePayload}}></button>
       </div>
     `,
       DemoCardComponent
@@ -864,7 +866,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     await render(hbs`
       <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
-        <button id='add-card' {{action editor.addCard 'demo-card' this.payload}}>
+        <button id='add-card' {{on 'click' (fn editor.addCard 'demo-card' this.payload)}}>
         </button>
       </MobiledocEditor>
     `);
@@ -909,7 +911,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
       hbs`
       <div id="demo-card">
         {{this.payload.foo}}
-        <button id='mutate-payload' {{action this.mutatePayload}}></button>
+        <button id='mutate-payload' {{on 'click' this.mutatePayload}}></button>
       </div>
     `,
       DemoCardComponent
@@ -922,7 +924,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
 
     await render(hbs`
       <MobiledocEditor @mobiledoc={{this.mobiledoc}} @cards={{this.cards}} as |editor|>
-        <button id='add-card' {{action editor.addCard 'demo-card' this.payload}}>
+        <button id='add-card' {{on 'click' (fn editor.addCard 'demo-card' this.payload)}}>
         </button>
       </MobiledocEditor>
     `);
@@ -1087,16 +1089,16 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     this.set('atoms', [createComponentAtom('ember-atom')]);
     this.set('atomText', 'atom text');
     this.set('atomPayload', { foo: 'bar' });
-    this.actions.onChange = (_mobiledoc) => (mobiledoc = _mobiledoc);
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.onChange = (_mobiledoc) => (mobiledoc = _mobiledoc);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     await render(hbs`
       <MobiledocEditor
-        @on-change={{action 'onChange'}}
-        @did-create-editor={{action 'didCreateEditor'}}
+        @on-change={{this.onChange}}
+        @did-create-editor={{this.didCreateEditor}}
         @mobiledoc={{this.mobiledoc}}
         @atoms={{this.atoms}}
       as |editor|>
-        <button id='add-atom' {{action editor.addAtom 'ember-atom' this.atomText this.atomPayload}}>Add Ember Atom</button>
+        <button id='add-atom' {{on 'click' (fn editor.addAtom 'ember-atom' this.atomText this.atomPayload)}}>Add Ember Atom</button>
       </MobiledocEditor>
     `);
 
@@ -1125,7 +1127,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     assert.expect(3);
     let editor;
 
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     let atom = this.registerAtomComponent(
       'demo-atom',
       hbs`<span id='demo-atom'>demo-atom</span>`
@@ -1133,7 +1135,7 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     this.set('atoms', [atom]);
     this.set('mobiledoc', simpleMobileDoc());
     await render(hbs`
-      <MobiledocEditor @did-create-editor={{action 'didCreateEditor'}} @mobiledoc={{this.mobiledoc}} @atoms={{this.atoms}} as |editor|>
+      <MobiledocEditor @did-create-editor={{this.didCreateEditor}} @mobiledoc={{this.mobiledoc}} @atoms={{this.atoms}} as |editor|>
       </MobiledocEditor>
     `);
 
@@ -1258,13 +1260,13 @@ module('Integration | Component | mobiledoc editor', function (hooks) {
     });
 
     let editor;
-    this.actions.didCreateEditor = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
 
     await render(hbs`
       <MobiledocEditor
         @mobiledoc={{this.mobiledoc}}
         @atoms={{this.atoms}}
-        @did-create-editor={{action 'didCreateEditor'}} as |editor|>
+        @did-create-editor={{this.didCreateEditor}} as |editor|>
       </MobiledocEditor>
     `);
 

--- a/tests/integration/components/mobiledoc-toolbar/component-test.js
+++ b/tests/integration/components/mobiledoc-toolbar/component-test.js
@@ -12,12 +12,6 @@ import { Range } from 'mobiledoc-kit';
 module('Integration | Component | mobiledoc toolbar', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
   const buttonTitles = [
     'Bold',
     'Italic',
@@ -54,9 +48,9 @@ module('Integration | Component | mobiledoc toolbar', function (hooks) {
     let text = 'Hello';
     this.set('mobiledoc', linkMobileDoc(text));
     let editor;
-    this.actions['did-create-editor'] = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{action 'did-create-editor'}} as |editor|>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{this.didCreateEditor}} as |editor|>
         <MobiledocToolbar @editor={{editor}} />
       </MobiledocEditor>
     `);
@@ -78,9 +72,9 @@ module('Integration | Component | mobiledoc toolbar', function (hooks) {
   test('List button is action when text is in list', async function (assert) {
     let text = 'Hello';
     this.set('mobiledoc', mobiledocWithList(text, 'ul'));
-    this.actions['did-create-editor'] = (editor) => (this._editor = editor);
+    this.didCreateEditor = (editor) => (this._editor = editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{action 'did-create-editor'}} as |editor|>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{this.didCreateEditor}} as |editor|>
         <MobiledocToolbar @editor={{editor}} />
       </MobiledocEditor>
     `);
@@ -138,9 +132,9 @@ module('Integration | Component | mobiledoc toolbar', function (hooks) {
     let text = 'Hello';
     this.set('mobiledoc', alignCenterMobileDoc(text));
     let editor;
-    this.actions['did-create-editor'] = (_editor) => (editor = _editor);
+    this.didCreateEditor = (_editor) => (editor = _editor);
     await render(hbs`
-      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{action 'did-create-editor'}} as |editor|>
+      <MobiledocEditor @mobiledoc={{this.mobiledoc}} @autofocus={{false}} @did-create-editor={{this.didCreateEditor}} as |editor|>
         <MobiledocToolbar @editor={{editor}} />
       </MobiledocEditor>
     `);


### PR DESCRIPTION
## Summary

Fixes the two scenarios added in #226 as `allowedToFail`:

| Scenario | Before | After |
| --- | --- | --- |
| `ember-lts-5.12-failing` | `allowedToFail`, boot-time `TypeError` | `ember-lts-5.12`, passing |
| `ember-6.12-failing` | `allowedToFail`, ~60 test failures | `ember-6.12`, passing |

## Root causes

1. **Runtime `.classify` TypeError.** `ember-export-application-global@2`'s auto-registered initializer calls `Ember.String.classify(config.modulePrefix)`, but Ember 5 removed `Ember.String`. The initializer only wires up `window.Dummy` during `ember serve` and isn't needed for addon testing, so it's removed.
2. **Addon code imports `@ember/string` as a runtime dep.** Three files under `addon/` (`mobiledoc-editor/component.js`, `mobiledoc-section-attribute-button/component.js`, `utils/titleize.js`) import from `@ember/string`. Pre-Ember-5 this resolved through the `ember-source` bundle; Ember 5+ requires it as an explicit package. Moved from devDeps to `dependencies` with range `^3.1.1 || ^4.0.0` so 3.x/4.x scenarios keep working.
3. **Ember 6 dropped the `{{action}}` template helper.** Migrated all usages in the two integration test files to `{{on}}` + `(fn ...)` (for modifier form) and direct `this.handler` references (for subexpression / arg form). The `this.actions = {}` + `this.send` scaffolding is replaced by plain `this.handlerName = fn` assignments. `@action` decorator usage from `@ember/object` is unaffected — only the template helper was removed.
4. **Ember 6 dropped separate `template:components/foo` + `component:foo` registration.** Updated `registerAtomComponent` / `registerCardComponent` helpers (and two inline registrations) to use `setComponentTemplate(template, class)` with `templateOnly()` for template-only components.

## Test matrix

- Passing: `ember-lts-3.28`, `ember-lts-4.4`, `ember-lts-4.12`, **`ember-lts-5.12`**, **`ember-6.12`**, `ember-classic`, `embroider-safe`
- `allowedToFail` (pre-existing, unchanged): `ember-lts-3.24`, `embroider-optimized`

## Test plan

- [x] `pnpm ember try:each` — 7 scenarios pass, 2 `allowedToFail` scenarios behave as expected.
- [x] `pnpm lint` — clean.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)